### PR TITLE
Answer initiative notification

### DIFF
--- a/app/events/decidim/initiatives/answer_initiative_event.rb
+++ b/app/events/decidim/initiatives/answer_initiative_event.rb
@@ -1,0 +1,8 @@
+# frozen-string_literal: true
+
+module Decidim
+  module Initiatives
+    class AnswerInitiativeEvent < Decidim::Events::SimpleEvent
+    end
+  end
+end

--- a/config/initializers/decidim_initiatives.rb
+++ b/config/initializers/decidim_initiatives.rb
@@ -20,7 +20,7 @@ if defined?(Decidim::Initiatives)
     config.default_signature_time_period_length = 12.months
 
     # Components enabled for a new initiative
-    config.default_components = [Decidim::Blog]
+    config.default_components = [:blogs]
 
     # Print functionality enabled. Allows the user to get
     # a printed version of the initiative from the administration

--- a/config/initializers/extends.rb
+++ b/config/initializers/extends.rb
@@ -6,3 +6,5 @@ require "extends/controllers/decidim/initiatives/create_initiative_controller_ex
 require "extends/controllers/decidim/initiatives/initiatives_controller_extends"
 require "extends/helpers/decidim/initiatives/initiative_helper_extends"
 require "extends/controllers/permissions/decidim/initiatives/permissions_extends"
+require "extends/helpers/decidim/icon_helper_extends"
+require "extends/commands/decidim/initiatives/admin/update_initiative_answer_extends"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,6 +39,12 @@ en:
           email_outro: You have received this notification because you are participating in "%{participatory_space_title}"
           email_subject: Your vote is still pending in %{participatory_space_title}
           notification_title: The vote on budget <a href="%{resource_path}">%{resource_title}</a> is still waiting for your confirmation in %{participatory_space_title}
+      initiatives:
+        initiative_answered:
+          email_intro: The initiative "%{resource_title}" has been answered.
+          email_outro: You have received this notification because you are following the initiative "%{resource_title}".
+          email_subject: Initiative "%{resource_title}" has been answered
+          notification_title: The initiative <a href="%{resource_path}">%{resource_title}</a> has been answered.
       users:
         user_officialized:
           email_intro: Participant %{name} (%{nickname}) has been officialized.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -39,6 +39,12 @@ fr:
           email_outro: Vous avez reçu cette notification parce que vous avez commencé à voter sur la concertation "%{participatory_space_title}"
           email_subject: Votre vote est toujours en attente sur la concertation %{participatory_space_title}
           notification_title: Votre vote pour le budget <a href="%{resource_path}">%{resource_title}</a> attend d'être finalisé sur la concertation %{participatory_space_title}
+      initiatives:
+        initiative_answered:
+          email_intro: La pétition "%{resource_title}" a reçu une réponse.
+          email_outro: Vous avez reçu cette notification parce que vous suivez la pétition "%{resource_title}".
+          email_subject: La pétition "%{resource_title}" a reçu une réponse.
+          notification_title: La pétition <a href="%{resource_path}">%{resource_title}</a> a reçu une réponse.
       users:
         user_officialized:
           email_intro: Le participant %{name} (%{nickname}) a été officialisé.

--- a/lib/extends/commands/decidim/initiatives/admin/update_initiative_answer_extends.rb
+++ b/lib/extends/commands/decidim/initiatives/admin/update_initiative_answer_extends.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module UpdateInitiativeAnswerExtends
+  def call
+    return broadcast(:invalid) if form.invalid?
+
+    @initiative = Decidim.traceability.update!(
+      initiative,
+      current_user,
+      attributes
+    )
+    notify_initiative_is_extended if @notify_extended
+    notify_initiative_is_answered if @notify_answered
+    broadcast(:ok, initiative)
+  rescue ActiveRecord::RecordInvalid
+    broadcast(:invalid, initiative)
+  end
+
+  private
+
+  def attributes
+    attrs = {
+      answer: form.answer,
+      answer_url: form.answer_url
+    }
+
+    attrs[:answered_at] = Time.current if form.answer.present?
+
+    if form.signature_dates_required?
+      attrs[:signature_start_date] = form.signature_start_date
+      attrs[:signature_end_date] = form.signature_end_date
+
+      if initiative.published? && form.signature_end_date != initiative.signature_end_date &&
+        form.signature_end_date > initiative.signature_end_date
+        @notify_extended = true
+      end
+    end
+
+    @notify_answered = form.answer != initiative.answer && !form.answer.values.all?(&:blank?)
+
+    attrs
+  end
+
+  def notify_initiative_is_answered
+    Decidim::EventsManager.publish(
+      event: "decidim.events.initiatives.initiative_answered",
+      event_class: Decidim::Initiatives::AnswerInitiativeEvent,
+      resource: initiative,
+      followers: initiative.followers
+    )
+  end
+end

--- a/lib/extends/commands/decidim/initiatives/admin/update_initiative_answer_extends.rb
+++ b/lib/extends/commands/decidim/initiatives/admin/update_initiative_answer_extends.rb
@@ -31,7 +31,7 @@ module UpdateInitiativeAnswerExtends
       attrs[:signature_end_date] = form.signature_end_date
 
       if initiative.published? && form.signature_end_date != initiative.signature_end_date &&
-        form.signature_end_date > initiative.signature_end_date
+         form.signature_end_date > initiative.signature_end_date
         @notify_extended = true
       end
     end

--- a/lib/extends/helpers/decidim/icon_helper_extends.rb
+++ b/lib/extends/helpers/decidim/icon_helper_extends.rb
@@ -3,7 +3,7 @@
 module IconHelperExtends
   def resource_icon(resource, options = {})
     if resource.instance_of?(Decidim::Initiative)
-      icon "bell", options
+      icon "initiatives", options
     elsif resource.instance_of?(Decidim::Comments::Comment)
       icon "comment-square", options
     elsif resource.respond_to?(:component)

--- a/lib/extends/helpers/decidim/icon_helper_extends.rb
+++ b/lib/extends/helpers/decidim/icon_helper_extends.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module IconHelperExtends
+  def resource_icon(resource, options = {})
+    if resource.instance_of?(Decidim::Initiative)
+      icon "bell", options
+    elsif resource.instance_of?(Decidim::Comments::Comment)
+      icon "comment-square", options
+    elsif resource.respond_to?(:component)
+      component_icon(resource.component, options)
+    elsif resource.respond_to?(:manifest)
+      manifest_icon(resource.manifest, options)
+    elsif resource.is_a?(Decidim::User)
+      icon "person", options
+    else
+      icon "bell", options
+    end
+  end
+end
+
+Decidim::IconHelper.module_eval do
+  prepend(IconHelperExtends)
+end

--- a/spec/commands/decidim/initiatives/admin/update_initiative_answer_spec.rb
+++ b/spec/commands/decidim/initiatives/admin/update_initiative_answer_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Initiatives
+    module Admin
+      describe UpdateInitiativeAnswer do
+        let(:form_klass) { Decidim::Initiatives::Admin::InitiativeAnswerForm }
+
+        context "when valid data" do
+          it_behaves_like "update an initiative answer" do
+            context "when the user is an admin" do
+              let(:current_user) { create(:user, :admin, organization: initiative.organization) }
+
+              before do
+                follower = create(:user, organization: organization)
+                create(:follow, followable: initiative, user: follower)
+              end
+
+              it "notifies the followers for extension" do
+                expect(Decidim::EventsManager)
+                  .to receive(:publish)
+                  .with(
+                    event: "decidim.events.initiatives.initiative_extended",
+                    event_class: Decidim::Initiatives::ExtendInitiativeEvent,
+                    resource: initiative,
+                    followers: [follower]
+                  )
+
+                command.call
+              end
+
+              it "notifies the followers for answer" do
+                expect(Decidim::EventsManager)
+                  .to receive(:publish)
+                  .with(
+                    event: "decidim.events.initiatives.initiative_answered",
+                    event_class: Decidim::Initiatives::AnswerInitiativeEvent,
+                    resource: initiative,
+                    followers: [follower]
+                  )
+
+                command.call
+              end
+
+              context "when the signature end time is not modified" do
+                let(:signature_end_date) { initiative.signature_end_date }
+
+                it "doesn't notify the followers" do
+                  expect(Decidim::EventsManager).not_to receive(:publish)
+
+                  command.call
+                end
+              end
+            end
+          end
+        end
+
+        context "when validation failure" do
+          let(:organization) { create(:organization) }
+          let!(:initiative) { create(:initiative, organization: organization) }
+          let!(:form) do
+            form_klass
+              .from_model(initiative)
+              .with_context(current_organization: organization, initiative: initiative)
+          end
+
+          let(:command) { described_class.new(initiative, form, initiative.author) }
+
+          it "broadcasts invalid" do
+            expect(initiative).to receive(:valid?)
+              .at_least(:once)
+              .and_return(false)
+            expect { command.call }.to broadcast :invalid
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

This PR sends a notification to the followers of an initiative when it's answered.

#### :pushpin: Related Issues
- [Notion card](https://www.notion.so/opensourcepolitics/bd4bf860eab94f9daca7da803f09e3b2?v=aed08bbf2b2e46e581cd0bfc1aefb1bb&p=a1153316819f4cb683c446f17f4917a8&pm=c)

#### Testing
*Describe the best way to test or validate your PR.*
* Follow a published initiative
* Access Backoffice
* Go to initiatives and answer the previously followed initiative
* Check your notifications
* Check your emails

#### Tasks
- [x] Add specs
- [x] Add note about overrides in OVERLOADS.md

### :camera: Screenshots
<img width="1173" alt="Screenshot 2022-11-29 at 12 23 16" src="https://user-images.githubusercontent.com/93646702/204516560-ca545116-9afc-4af9-aa69-fd0329259868.png">

### Additionnal explications

 - The initializer file is modified because the previous config was generating wrong path
 - The icon helper is overriden because of [this issue](https://github.com/decidim/decidim/issues/10129) in Decidim