### PR TITLE
Add socio_demographic authorization handler on CESE's platform

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,10 +12,13 @@ gem "decidim-initiatives", git: "https://github.com/decidim/decidim.git", branch
 # gem "acts_as_textcaptcha", "~> 4.5.1"
 # gem "decidim-homepage_interactive_map", git: "https://github.com/OpenSourcePolitics/decidim-module-homepage_interactive_map.git", branch: "bump/0.25-stable"
 # gem "decidim-phone_authorization_handler", git: "https://github.com/OpenSourcePolitics/decidim-module_phone_authorization_handler", branch: "bump/0.25-stable"
+gem "decidim-extended_socio_demographic_authorization_handler", git: "https://github.com/OpenSourcePolitics/decidim-module-extended_socio_demographic_authorization_handler.git",
+                                                                branch: "cese"
 # gem "decidim-question_captcha", git: "https://github.com/OpenSourcePolitics/decidim-module-question_captcha.git", branch: DECIDIM_VERSION
 gem "decidim-spam_detection", git: "https://github.com/OpenSourcePolitics/decidim-spam_detection.git"
 gem "decidim-term_customizer", git: "https://github.com/mainio/decidim-module-term_customizer.git", branch: "develop"
 gem "omniauth-france_connect", git: "https://github.com/OpenSourcePolitics/omniauth-france_connect"
+
 # gem "omniauth-publik", git: "https://github.com/OpenSourcePolitics/omniauth-publik", branch: "v0.0.9"
 #
 # gem "decidim-decidim_awesome", "0.8.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/OpenSourcePolitics/decidim-module-extended_socio_demographic_authorization_handler.git
+  revision: 51be28cac256bc25c176e8a203aae7a00a9626bd
+  branch: cese
+  specs:
+    decidim-extended_socio_demographic_authorization_handler (0.26.1)
+      decidim-core (~> 0.27)
+
+GIT
   remote: https://github.com/OpenSourcePolitics/decidim-spam_detection.git
   revision: 964a091ff49cb066a430610cbfbe61886d06f401
   specs:
@@ -955,6 +963,7 @@ DEPENDENCIES
   dalli
   decidim!
   decidim-dev!
+  decidim-extended_socio_demographic_authorization_handler!
   decidim-initiatives!
   decidim-spam_detection!
   decidim-term_customizer!


### PR DESCRIPTION
#### 🎩 Description

Hello ! I've made this pull request to add the extended socio_demographic authorization handler following the CESE branch that we created few days ago to our application.

#### 📌 Related Issues

Related to [Add gem extended socio_demographic AH](https://www.notion.so/opensourcepolitics/CESE-Add-gem-socio_demographic_AH-82488c6c08a845c2aac5155e64d1ab92)

#### 💻 Testing

* Initialize normally your instance
* Login as user or admin
* Go to your profile
* Go to `Authorizations`
* Match that there is `Additional Informations`
* Click on it and fill in your authorization

#### 📓 Tasks
 
* Import gem on our `Gemfile`
* Run `bundle install`