### PR TITLE
Add missing queue exports

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -9,6 +9,7 @@
   - user_report
   - block_user
   - scheduled
+  - exports
 
 :schedule:
   CalculateAllMetrics:


### PR DESCRIPTION
#### Description 

Job `PreloadOpenData` defined in sidekiq-scheduler call the rake task `"decidim:open_data:export"` which will execute asynchronous jobs on queue `exports` which is missing.


See `decidim-core/app/jobs/decidim/open_data_job.rb`