### PR TITLE
backport fix edition and creation form for initiatives missing form fields

### DIFF
--- a/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
+++ b/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
@@ -1,0 +1,109 @@
+<% content_for :back_link do %>
+  <%= link_to :back do %>
+    <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+    <%= t(".back") %>
+  <% end %>
+<% end %>
+
+<div class="row column">
+  <div class="medium-centered">
+    <div class="callout secondary">
+      <%== t ".fill_data_help" %>
+      <%= link_to t(".more_information"), decidim.page_path("initiatives"), target: "_blank" %>.
+    </div>
+  </div>
+</div>
+<br>
+<div class="row">
+  <div class="medium-centered">
+    <div class="card">
+      <div class="card__content">
+        <%= decidim_form_for(@form, url: next_wizard_path, method: :put, html: { class: "form new_initiative_form", novalidate: false }) do |f| %>
+          <%= form_required_explanation %>
+          <div class=section>
+            <% if single_initiative_type? %>
+              <%= f.hidden_field :type_id %>
+            <% else %>
+              <div class="field">
+                <%= f.select :type_id,
+                             initiative_type_options,
+                             {},
+                             {
+                               disabled: !@form.signature_type_updatable?,
+                               "data-scope-selector": "initiative_decidim_scope_id",
+                               "data-scope-id": f.object.scope_id.to_s,
+                               "data-scope-search-url": decidim_initiatives.initiative_type_scopes_search_url,
+                               "data-signature-types-selector": "initiative_signature_type",
+                               "data-signature-type": current_initiative&.signature_type,
+                               "data-signature-types-search-url": decidim_initiatives.initiative_type_signature_types_search_url
+                             } %>
+              </div>
+            <% end %>
+
+            <div class="field">
+              <%= f.text_field :title, autofocus: true %>
+            </div>
+
+            <div class="field">
+              <%= f.editor :description, lines: 8, toolbar: :full %>
+            </div>
+
+            <div class="field">
+              <%= f.text_field :hashtag %>
+            </div>
+
+            <% signature_type_options = signature_type_options(f.object) %>
+            <% if signature_type_options.length == 1 %>
+              <%= f.hidden_field :signature_type, value: signature_type_options.first.last %>
+            <% else %>
+              <div class="field">
+                <%= f.select :signature_type, signature_type_options %>
+              </div>
+            <% end %>
+            <% if initiative_type.custom_signature_end_date_enabled? %>
+              <div class="field">
+                <%= f.date_field :signature_end_date %>
+              </div>
+            <% end %>
+            <% if scopes.length == 1 %>
+              <%= f.hidden_field :scope_id, value: scopes.first.scope&.id %>
+            <% else %>
+              <div class="field">
+                <%= f.select :scope_id,
+                             scopes.map { |scope| [translated_attribute(scope.scope_name), scope&.scope&.id] },
+                             required: true,
+                             include_blank: t(".select_scope") %>
+              </div>
+            <% end %>
+            <% if initiative_type.area_enabled? %>
+              <div class="field">
+                <%= f.areas_select :area_id, areas_for_select(current_organization), prompt: t(".select_area") %>
+              </div>
+            <% end %>
+            <% if Decidim::UserGroups::ManageableUserGroups.for(current_user).verified.any? %>
+              <div class="field">
+                <%= f.select :decidim_user_group_id,
+                             Decidim::UserGroups::ManageableUserGroups.for(current_user).verified.map { |g| [g.name, g.id] },
+                             include_blank: current_user.name, help_text: t(".decidim_user_group_id_help") %>
+              </div>
+            <% end %>
+            <% if initiative_type.attachments_enabled? %>
+              <fieldset class="attachments_container">
+                <legend><%= t("attachment_legend", scope: "decidim.initiatives.form") %></legend>
+
+                <div class="row column">
+                  <%= f.attachment :documents,
+                                   multiple: true,
+                                   label: t("add_attachments", scope: "decidim.initiatives.form") %>
+                </div>
+              </fieldset>
+            <% end %>
+          </div>
+          <div class="actions">
+            <%= f.submit t(".continue"), class: "button expanded", data: { disable_with: true } %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/decidim/initiatives/initiatives/_form.html.erb
+++ b/app/views/decidim/initiatives/initiatives/_form.html.erb
@@ -1,0 +1,115 @@
+<%= form_required_explanation %>
+<% unless single_initiative_type? %>
+  <div class="field">
+    <%= form.select :type_id,
+                    initiative_type_options,
+                    {},
+                    {
+                      disabled: !@form.signature_type_updatable?,
+                      "data-scope-selector": "initiative_decidim_scope_id",
+                      "data-scope-id": form.object.scope_id.to_s,
+                      "data-scope-search-url": decidim_initiatives.initiative_type_scopes_search_url,
+                      "data-signature-types-selector": "initiative_signature_type",
+                      "data-signature-type": current_initiative.signature_type,
+                      "data-signature-types-search-url": decidim_initiatives.initiative_type_signature_types_search_url
+                    } %>
+  </div>
+<% end %>
+
+<div class="field">
+  <%= form.text_field :title, autofocus: true, disabled: !allowed_to?(:update, :initiative, initiative: current_initiative), value: translated_attribute(@form.title) %>
+</div>
+
+<div class="field">
+  <%= form.editor :description, toolbar: :full, lines: 8, disabled: !allowed_to?(:update, :initiative, initiative: current_initiative), value: translated_attribute(@form.description) %>
+</div>
+
+<div class="field">
+  <%= form.text_field :hashtag, disabled: !allowed_to?(:update, :initiative, initiative: current_initiative) %>
+</div>
+
+<% signature_type_options = signature_type_options(form.object) %>
+<% if signature_type_options.length == 1 %>
+  <%= form.hidden_field :signature_type %>
+<% else %>
+  <div class="field">
+    <%= form.select :signature_type, [], {}, { disabled: !@form.signature_type_updatable? } %>
+  </div>
+<% end %>
+<% if can_edit_custom_signature_end_date?(current_initiative) %>
+  <div class="row column">
+    <%= form.date_field :signature_end_date, disabled: !allowed_to?(:update, :initiative, initiative: current_initiative) %>
+  </div>
+<% end %>
+
+<div class="field">
+  <%= form.select :scope_id,
+                  @form.available_scopes.map { |scope| [translated_attribute(scope.scope_name), scope&.scope&.id] },
+                  { disabled: !@form.state_updatable? } %>
+</div>
+
+<% if current_initiative.area_enabled? %>
+  <div class="field">
+    <%= form.areas_select :area_id,
+                          areas_for_select(current_organization),
+                          {
+                            selected: current_initiative.decidim_area_id,
+                            include_blank: current_initiative.decidim_area_id.blank? || current_initiative.created?
+                          },
+                          disabled: !@form.area_updatable? %>
+  </div>
+<% end %>
+
+<div class="field">
+  <%= form.select :state,
+                  Decidim::Initiative.states.keys.map { |state| [I18n.t(state, scope: "decidim.initiatives.admin_states"), state] },
+                  {},
+                  { disabled: !@form.state_updatable? } %>
+</div>
+
+<% if current_initiative.type.attachments_enabled? %>
+  <fieldset class="attachments_container">
+    <legend><%= t("attachment_legend", scope: "decidim.initiatives.form") %></legend>
+
+    <% if @form.photos.any? %>
+      <% @form.photos.each do |photo| %>
+        <div class="callout gallery__item" data-closable>
+          <%= image_tag photo.thumbnail_url, class: "thumbnail", alt: photo.file.filename %>
+          <%= form.hidden_field :photos, multiple: true, value: photo.id, id: "photo-#{photo.id}" %>
+          <button class="close-button"
+                  aria-label="<%= t("delete_attachment", scope: "decidim.initiatives.form") %>"
+                  title="<%= t("delete_attachment", scope: "decidim.initiatives.form") %>"
+                  type="button"
+                  data-close>
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+      <% end %>
+    <% end %>
+    <% if @form.documents.any? %>
+      <% @form.documents.each do |document| %>
+        <div class="callout" data-closable>
+          <%= link_to translated_attribute(document.title), document.url %>
+          <small><%= document.file_type %> <%= number_to_human_size(document.file_size) %></small>
+          <%= form.hidden_field :documents, multiple: true, value: document.id, id: "document-#{document.id}" %>
+          <button class="close-button"
+                  aria-label="<%= t("delete_attachment", scope: "decidim.initiatives.form") %>"
+                  title="<%= t("delete_attachment", scope: "decidim.initiatives.form") %>"
+                  type="button" data-close>
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+      <% end %>
+    <% end %>
+
+    <div class="row column">
+      <%= form.file_field :add_documents, multiple: true, label: t("add_attachments", scope: "decidim.initiatives.form") %>
+    </div>
+  </fieldset>
+<% end %>
+<% if current_initiative.type.promoting_committee_enabled? %>
+  <%= render partial: "committee_members" %>
+<% end %>
+<% content_for :js_content do %>
+  <%= javascript_pack_tag "decidim_initiatives" %>
+<% end %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -88,6 +88,9 @@ ignore_missing:
  - devise.shared.links.sign_in_with_provider
  - layouts.decidim.header.user_menu
  - decidim.initiatives.initiatives.index_header.new_initiative
+ - decidim.initiatives.admin.content_blocks.highlighted_initiatives.order.*
+ - decidim.initiatives.create_initiative.fill_data.*
+ - decidim.initiatives.form.*
 
 # Consider these keys used:
 ignore_unused:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -65,6 +65,8 @@ en:
               most_popular: Most popular
               random: Randomly
       create_initiative:
+        fill_data:
+          decidim_user_group_id_help: It's not possible to change initiative authorship after creation
         select_initiative_type:
           verification_required: Verify your account to promote this initiative
       modal:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -59,6 +59,8 @@ fr:
           notification_title: Le participant <a href="%{resource_path}">%{resource_title}</a> a tenté de se faire vérifier avec les données de l'utilisateur représenté <a href="%{managed_user_path}">%{managed_user_name}</a>.
     initiatives:
       create_initiative:
+        fill_data:
+          decidim_user_group_id_help: Il est impossible de changer l'auteur de la pétition après la création
         select_initiative_type:
           verification_required: Vérifiez votre compte pour signer la pétition
       modal:

--- a/lib/extends/controllers/decidim/initiatives/initiatives_controller_extends.rb
+++ b/lib/extends/controllers/decidim/initiatives/initiatives_controller_extends.rb
@@ -4,6 +4,8 @@ module InitiativesControllerExtends
   extend ActiveSupport::Concern
 
   included do
+    helper Decidim::Initiatives::CreateInitiativeHelper
+
     helper_method :available_initiative_types
   end
 end

--- a/spec/system/create_initiative_spec.rb
+++ b/spec/system/create_initiative_spec.rb
@@ -474,9 +474,14 @@ describe "Initiative", type: :system do
             find_button("Continue").click
           end
 
-          it "have no 'Initiative type' grey field" do
+          it "does not show select input for initiative_type" do
             expect(page).not_to have_content("Initiative type")
-            expect(page).not_to have_css("#type_description")
+            expect(page).not_to have_css("#initiative_type_id")
+          end
+
+          it "has a hidden field with the selected initiative type" do
+            expect(page).to have_xpath("//input[@id='initiative_type_id']", visible: :all)
+            expect(find(:xpath, "//input[@id='initiative_type_id']", visible: :all).value).to eq(initiative_type.id.to_s)
           end
         end
 
@@ -500,10 +505,24 @@ describe "Initiative", type: :system do
             end
           end
 
+          it "shows select input for initiative_type" do
+            expect(page).to have_content("Type")
+            expect(find(:xpath, "//select[@id='initiative_type_id']", visible: :all).value).to eq(initiative_type.id.to_s)
+          end
+
           it "shows information collected in previous steps already filled" do
-            expect(find(:xpath, "//input[@id='initiative_type_id']", visible: :all).value).to eq(initiative_type.id.to_s)
             expect(find(:xpath, "//input[@id='initiative_title']").value).to eq(translated(initiative.title, locale: :en))
             expect(find(:xpath, "//input[@id='initiative_description']", visible: :all).value).to eq(translated(initiative.description, locale: :en))
+          end
+
+          it "shows input for signature collection type" do
+            expect(page).to have_content("Signature collection type")
+            expect(find(:xpath, "//select[@id='initiative_signature_type']", visible: :all).value).to eq("online")
+          end
+
+          it "shows input for hashtag" do
+            expect(page).to have_content("Hashtag")
+            expect(find(:xpath, "//input[@id='initiative_hashtag']", visible: :all).value).to eq("")
           end
 
           context "when only one signature collection and scope are available" do
@@ -513,7 +532,7 @@ describe "Initiative", type: :system do
             it "hides and automatically selects the values" do
               expect(page).not_to have_content("Signature collection type")
               expect(page).not_to have_content("Scope")
-              expect(find(:xpath, "//input[@id='initiative_type_id']", visible: :all).value).to eq(initiative_type.id.to_s)
+              expect(find(:xpath, "//select[@id='initiative_type_id']", visible: :all).value).to eq(initiative_type.id.to_s)
               expect(find(:xpath, "//input[@id='initiative_signature_type']", visible: :all).value).to eq("offline")
             end
           end


### PR DESCRIPTION
This PR backports [this one](https://github.com/decidim/decidim/pull/10006)

#### :tophat: What? Why?

This PR fixes an issue that the form for initiative creation and update do not display the same fields.
- Added the field `hashtag` to creation form
- Added condition in update-form to only display `signature_type`-dropdown when more than one option exists (same as creation-form)
- Renamed CreateInitiativeHelper to SignatureTypeOptionsHelper

#### :pushpin: Related Issues
*Link your PR to an issue*
- Fixes https://github.com/decidim/decidim/issues/9922

#### Testing
*Describe the best way to test or validate your PR.*
 - create new initiative then edit it
 - Forms should have the same fields
 - Repeat test with one/multiple signature_type-options

The failing spec will pass when [this pr](https://github.com/OpenSourcePolitics/decidim-cese/pull/12) will be merged