### PR TITLE
[Fix] - SMS gateway service

### DIFF
--- a/app/services/sms_gateway_service.rb
+++ b/app/services/sms_gateway_service.rb
@@ -11,8 +11,8 @@ class SMSGatewayService
     @mobile_phone_number = mobile_phone_number
     @code = code
     @url = "https://ssl.etoilediese.fr/envoi/sms/envoi.php"
-    @username = ENV.fetch("SMS_GATEWAY_USERNAME", nil)
-    @password = ENV.fetch("SMS_GATEWAY_PASSWORD", nil)
+    @username = Rails.application.secrets.dig(:decidim, :verifications, :sms_gateway_service, :username)
+    @password = Rails.application.secrets.dig(:decidim, :verifications, :sms_gateway_service, :password)
     @message = I18n.t("sms_verification_workflow.message", code: code)
     @type = "sms"
   end
@@ -21,14 +21,19 @@ class SMSGatewayService
     url = URI("#{@url}?u=#{@username}&p=#{@password}&t=#{@message}&n=#{@mobile_phone_number}&f=#{@type}")
     https = Net::HTTP.new(url.host, url.port)
     https.use_ssl = true
-    request = Net::HTTP::Get.new(url)
-    response = https.request(request)
+    response = https.get(url)
     response = response.read_body
 
     Rails.logger.info("#########################################################")
     Rails.logger.info("SMS Verification code delivered to #{mobile_phone_number}")
     Rails.logger.info("SMS Verification API response #{response}")
     Rails.logger.info("#########################################################")
+
     true
+  rescue URI::InvalidURIError => e
+    Rails.logger.error("[SMSGatewayService] - Error #{e.message}")
+    Rails.logger.error("[SMSGatewayService] - Ensure env variable 'SMS_GATEWAY_USERNAME' and 'SMS_GATEWAY_PASSWORD' are defined")
+    Rails.logger.error("[SMSGatewayService] - Ensure there is no special chars in I18n translation : 'sms_verification_workflow.message'")
+    false
   end
 end

--- a/app/services/sms_gateway_service.rb
+++ b/app/services/sms_gateway_service.rb
@@ -22,18 +22,24 @@ class SMSGatewayService
     https = Net::HTTP.new(url.host, url.port)
     https.use_ssl = true
     response = https.get(url)
-    response = response.read_body
+    res_body = response.read_body
+    raise ArgumentError, res_body if res_body.include?("Echec")
 
     Rails.logger.info("#########################################################")
     Rails.logger.info("SMS Verification code delivered to #{mobile_phone_number}")
-    Rails.logger.info("SMS Verification API response #{response}")
+    Rails.logger.info("SMS Verification API response #{res_body}")
     Rails.logger.info("#########################################################")
 
     true
   rescue URI::InvalidURIError => e
     Rails.logger.error("[SMSGatewayService] - Error #{e.message}")
-    Rails.logger.error("[SMSGatewayService] - Ensure env variable 'SMS_GATEWAY_USERNAME' and 'SMS_GATEWAY_PASSWORD' are defined")
     Rails.logger.error("[SMSGatewayService] - Ensure there is no special chars in I18n translation : 'sms_verification_workflow.message'")
+
+    false
+  rescue ArgumentError => e
+    Rails.logger.error("[SMSGatewayService] - Error '#{e.message}'")
+    Rails.logger.error("[SMSGatewayService] - Ensure env variable 'SMS_GATEWAY_USERNAME' and 'SMS_GATEWAY_PASSWORD' are defined")
+
     false
   end
 end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -189,4 +189,4 @@ fr:
         conversations: Conversations
         notifications: Notifications
   sms_verification_workflow:
-    message: Bonjour, %{code} est le code pour vous authentifier sur la plateforme de pétitions du CESE.
+    message: Bonjour, %{code} est le code pour vous authentifier sur la plateforme de petitions du CESE.

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -13,6 +13,10 @@
 default: &default
   asset_host: <%= ENV["ASSET_HOST"] %>
   decidim:
+    verifications:
+      sms_gateway_service:
+        username: <%= ENV["SMS_GATEWAY_USERNAME"].presence %>
+        password: <%= ENV["SMS_GATEWAY_PASSWORD"].presence %>
     initiatives:
       permissions:
         comments:

--- a/spec/services/sms_gateway_service_spec.rb
+++ b/spec/services/sms_gateway_service_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe SMSGatewayService do
+  let(:subject) { described_class.new(mobile_phone_number, code) }
+  let(:mobile_phone_number) { "0600000000" }
+  let(:code) { "0123456" }
+
+  it "allows to setup service" do
+    expect(subject.mobile_phone_number).to eq("0600000000")
+    expect(subject.code).to eq("0123456")
+  end
+
+  describe "#deliver_code" do
+    let(:api_url) { "https://ssl.etoilediese.fr/envoi/sms/envoi.php?f=sms&n=0600000000&p=api_password&t=Hello,%20here%20is%20the%20code%20to%20authenticate%20yourself%20on%20the%20CESE%20initiatives%20platform:%200123456&u=api_username" }
+    let(:api_username) { "api_username" }
+    let(:api_password) { "api_password" }
+    let(:response_body) { "123456789" }
+
+    before do
+      allow(Rails.application.secrets).to receive(:dig).with(:decidim, :verifications, :sms_gateway_service, :username).and_return(api_username)
+      allow(Rails.application.secrets).to receive(:dig).with(:decidim, :verifications, :sms_gateway_service, :password).and_return(api_password)
+      stub_request(:get, api_url).
+        with(
+          headers: {
+            'Accept'=>'*/*',
+            'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Host'=>'ssl.etoilediese.fr',
+            'User-Agent'=>'Ruby'
+          }).
+        to_return(status: 200, body: response_body, headers: {})
+    end
+
+    it "send request to external service" do
+      expect(subject.deliver_code).to be_truthy
+    end
+
+    context "when credentials are missing" do
+      let(:response_body) { "Echec: Veuillez vous identifier" }
+
+      it "rescue error and returns false" do
+        expect(subject.deliver_code).to be_falsey
+      end
+    end
+
+    context "when message translation contains special chars" do
+      let(:api_url) { "https://ssl.etoilediese.fr/envoi/sms/envoi.php?f=sms&n=0600000000&p=api_password&t=Hello,%20here%20is%20the%20code%20to%20authenticate%20yourself%20on%20the%20CESE%20initiatives%20platform:%200123456&u=api_username" }
+
+      before do
+        allow(I18n).to receive(:t).with("sms_verification_workflow.message", code: code).and_return("Hello, here is the code to authenticate yourself on pétitions: 0123456")
+      end
+      it "rescue error and returns false" do
+        expect(subject.deliver_code).to be_falsey
+      end
+    end
+  end
+end

--- a/spec/services/sms_gateway_service_spec.rb
+++ b/spec/services/sms_gateway_service_spec.rb
@@ -1,7 +1,10 @@
-require 'spec_helper'
+# frozen_string_literal: true
+
+require "spec_helper"
 
 describe SMSGatewayService do
-  let(:subject) { described_class.new(mobile_phone_number, code) }
+  subject { described_class.new(mobile_phone_number, code) }
+
   let(:mobile_phone_number) { "0600000000" }
   let(:code) { "0123456" }
 
@@ -19,15 +22,16 @@ describe SMSGatewayService do
     before do
       allow(Rails.application.secrets).to receive(:dig).with(:decidim, :verifications, :sms_gateway_service, :username).and_return(api_username)
       allow(Rails.application.secrets).to receive(:dig).with(:decidim, :verifications, :sms_gateway_service, :password).and_return(api_password)
-      stub_request(:get, api_url).
-        with(
+      stub_request(:get, api_url)
+        .with(
           headers: {
-            'Accept'=>'*/*',
-            'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-            'Host'=>'ssl.etoilediese.fr',
-            'User-Agent'=>'Ruby'
-          }).
-        to_return(status: 200, body: response_body, headers: {})
+            "Accept" => "*/*",
+            "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+            "Host" => "ssl.etoilediese.fr",
+            "User-Agent" => "Ruby"
+          }
+        )
+        .to_return(status: 200, body: response_body, headers: {})
     end
 
     it "send request to external service" do
@@ -48,6 +52,7 @@ describe SMSGatewayService do
       before do
         allow(I18n).to receive(:t).with("sms_verification_workflow.message", code: code).and_return("Hello, here is the code to authenticate yourself on pétitions: 0123456")
       end
+
       it "rescue error and returns false" do
         expect(subject.deliver_code).to be_falsey
       end


### PR DESCRIPTION
#### Description

SMS Gateway Service returns success message even if sms is not sent. 

Reasons : 
- Presence of invalid special chars in I18n translation
- Credentials not defined

#### Done

- Rescue errors on API and return false
- Rescue URI encoding error and return false
- Return true
- Move env variable in Rails application secrets

#### How to test 

* Define env vars `SMS_GATEWAY_USERNAME` and `SMS_GATEWAY_PASSWORD`
* Run application locally
* Fill SMS AH
* See sms received with current locale

**NOTE:** Env variables `SMS_GATEWAY_PASSWORD` `SMS_GATEWAY_PASSWORD`