### PR TITLE
[Feature] Add email notifications 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ ruby RUBY_VERSION
 
 gem "decidim", git: "https://github.com/decidim/decidim.git", branch: DECIDIM_VERSION
 gem "decidim-initiatives", git: "https://github.com/decidim/decidim.git", branch: DECIDIM_VERSION
+gem "rack-attack"
 
 ## Block gems /!\ Required comment for : $ rake app:upgrade
 gem "decidim-decidim_awesome", git: "https://github.com/decidim-ice/decidim-module-decidim_awesome.git", branch: "main"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -993,6 +993,7 @@ DEPENDENCIES
   parallel_tests (~> 3.7)
   passenger
   puma (>= 5.6.2)
+  rack-attack
   rubocop-faker
   sendgrid-ruby
   sentry-rails

--- a/app/mailers/decidim/blogs/blogs_mailer.rb
+++ b/app/mailers/decidim/blogs/blogs_mailer.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Blogs
+    class BlogsMailer < Decidim::ApplicationMailer
+      include Decidim::TranslatableAttributes
+      include Decidim::SanitizeHelper
+
+      helper Decidim::TranslatableAttributes
+      helper Decidim::SanitizeHelper
+
+      def notify_post(post, user, initiative)
+        return if user.email.blank?
+        return unless user.follows?(initiative)
+
+        @organization = post.organization
+        @link = resource_locator(post).path
+
+        @body = I18n.t(
+          "decidim.blogs.blogs_mailer.notify_post.body",
+          author: post.author.name,
+          title: translated_attribute(initiative.title),
+          post_title: translated_attribute(post.title)
+        )
+
+        @subject = I18n.t(
+          "decidim.blogs.blogs_mailer.notify_post.subject",
+          title: translated_attribute(initiative.title)
+        )
+
+        mail(to: "#{user.name} <#{user.email}>", subject: @subject)
+      end
+
+      private
+
+      def resource_locator(resource)
+        Decidim::ResourceLocatorPresenter.new(resource)
+      end
+    end
+  end
+end

--- a/app/views/decidim/blogs/blogs_mailer/_initiative_link.html.erb
+++ b/app/views/decidim/blogs/blogs_mailer/_initiative_link.html.erb
@@ -1,0 +1,5 @@
+<% if @link %>
+  <p>
+    <%= t(".check_post_details") %> <%= link_to t(".here"), @link %>
+  </p>
+<% end %>

--- a/app/views/decidim/blogs/blogs_mailer/notify_post.html.erb
+++ b/app/views/decidim/blogs/blogs_mailer/notify_post.html.erb
@@ -1,0 +1,4 @@
+<%= decidim_sanitize @body %>
+
+<br><br>
+<%= render partial: "initiative_link" %>

--- a/app/views/decidim/initiatives/initiatives_mailer/notify_answer.html.erb
+++ b/app/views/decidim/initiatives/initiatives_mailer/notify_answer.html.erb
@@ -1,0 +1,9 @@
+<%= decidim_sanitize @body %>
+
+<div class="row">
+  <p>
+    <%= t("decidim.initiatives.initiatives_mailer.new_answer_message", answer: @answer) %>
+  </p>
+</div>
+<br><br>
+<%= render partial: "initiative_link" %>

--- a/config/initializers/extends.rb
+++ b/config/initializers/extends.rb
@@ -13,3 +13,5 @@ require "extends/queries/decidim/initiatives/organization_prioritized_initiative
 require "extends/cells/decidim/initiatives/content_blocks/highlighted_initiatives_settings_form_cell_extends"
 require "extends/commands/decidim/initiatives/update_initiative_extends"
 require "extends/controllers/decidim/devise/account_controller_extends"
+require "extends/mailers/decidim/initiatives/initiative_mailer_extends"
+require "extends/commands/decidim/blogs/admin/create_post_extends"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,13 @@ en:
         name: Identity Verification Form
       osp_authorization_workflow:
         name: Authorization procedure
+    blogs:
+      blogs_mailer:
+        initiative_link:
+          check_post_details: Check Post Details
+        notify_post:
+          body: "%{author} has published a new post in the initiative %{title} named %{post_title}."
+          subject: New post published in the initiative %{title}
     devise:
       sessions:
         new:
@@ -73,6 +80,10 @@ en:
           decidim_user_group_id_help: It's not possible to change initiative authorship after creation
         select_initiative_type:
           verification_required: Verify your account to promote this initiative
+      initiatives_mailer:
+        answer_body_for: There is a new answer for the initiative "%{title}".
+        answer_for: An initiative that you are following has been answered
+        new_answer_message: The answer to this initiative is "%{answer}".
       modal:
         not_authorized:
           authorizations_page: View authorizations

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -37,8 +37,8 @@ fr:
         initiative_link:
           check_post_details: Voir les détails de l'article
         notify_post:
-          body: "%{author} a publié un nouvel article dans l'initiative %{title} intitulé %{post_title}."
-          subject: Nouvel article publié dans l'initiative %{title}
+          body: "%{author} a publié un nouvel article dans la pétition %{title} intitulé %{post_title}."
+          subject: Nouvel article publié dans la pétition %{title}
     devise:
       sessions:
         new:
@@ -76,8 +76,8 @@ fr:
           verification_required: Vérifiez votre compte pour signer la pétition
       initiatives_mailer:
         answer_body_for: Il y a une nouvelle réponse pour la pétition "%{title}".
-        answer_for: Une initiative que vous suivez a reçu une réponse
-        new_answer_message: La réponse à cette nouvelle initiative est "%{answer}".
+        answer_for: Une pétition que vous suivez a reçu une réponse
+        new_answer_message: La réponse à cette pétition est "%{answer}".
       modal:
         not_authorized:
           authorizations_page: Voir les vérifications

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -32,6 +32,13 @@ fr:
         name: Formulaire de vérification d'identité
       osp_authorization_workflow:
         name: Procédure d'autorisation
+    blogs:
+      blogs_mailer:
+        initiative_link:
+          check_post_details: Voir les détails de l'article
+        notify_post:
+          body: "%{author} a publié un nouvel article dans l'initiative %{title} intitulé %{post_title}."
+          subject: Nouvel article publié dans l'initiative %{title}
     devise:
       sessions:
         new:
@@ -67,6 +74,10 @@ fr:
           decidim_user_group_id_help: Il est impossible de changer l'auteur de la pétition après la création
         select_initiative_type:
           verification_required: Vérifiez votre compte pour signer la pétition
+      initiatives_mailer:
+        answer_body_for: Il y a une nouvelle réponse pour la pétition "%{title}".
+        answer_for: Une initiative que vous suivez a reçu une réponse
+        new_answer_message: La réponse à cette nouvelle initiative est "%{answer}".
       modal:
         not_authorized:
           authorizations_page: Voir les vérifications

--- a/lib/extends/commands/decidim/blogs/admin/create_post_extends.rb
+++ b/lib/extends/commands/decidim/blogs/admin/create_post_extends.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Blogs
+    module Admin
+      module CreatePostExtends
+        def call
+          return broadcast(:invalid) if @form.invalid?
+
+          transaction do
+            create_post!
+            send_notification
+          end
+
+          @post.participatory_space.followers.each do |follower|
+            Decidim::Blogs::BlogsMailer
+              .notify_post(@post, follower, @post.participatory_space)
+              .deliver_later
+          end
+
+          broadcast(:ok, @post)
+        end
+      end
+    end
+  end
+end
+
+Decidim::Blogs::Admin::CreatePost.class_eval do
+  prepend Decidim::Blogs::Admin::CreatePostExtends
+end

--- a/lib/extends/commands/decidim/initiatives/admin/update_initiative_answer_extends.rb
+++ b/lib/extends/commands/decidim/initiatives/admin/update_initiative_answer_extends.rb
@@ -11,6 +11,12 @@ module UpdateInitiativeAnswerExtends
     )
     notify_initiative_is_extended if @notify_extended
     notify_initiative_is_answered if @notify_answered
+
+    initiative.followers.each do |follower|
+      Decidim::Initiatives::InitiativesMailer
+        .notify_answer(initiative, follower)
+        .deliver_later
+    end
     broadcast(:ok, initiative)
   rescue ActiveRecord::RecordInvalid
     broadcast(:invalid, initiative)

--- a/lib/extends/mailers/decidim/initiatives/initiative_mailer_extends.rb
+++ b/lib/extends/mailers/decidim/initiatives/initiative_mailer_extends.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module InitiativesMailerExtends
+  def notify_answer(initiative, user)
+    return if user.email.blank?
+    return unless user.follows?(initiative)
+
+    @organization = initiative.organization
+    @link = initiative_url(initiative, host: @organization.host)
+    @answer = translated_attribute(initiative.answer).gsub(%r{</?[^>]*>}, "") if initiative.answer.present?
+
+    with_user(user) do
+      @body = I18n.t(
+        "decidim.initiatives.initiatives_mailer.answer_body_for",
+        title: translated_attribute(initiative.title)
+      )
+
+      @subject = I18n.t(
+        "decidim.initiatives.initiatives_mailer.answer_for",
+        title: translated_attribute(initiative.title)
+      )
+
+      mail(to: "#{user.name} <#{user.email}>", subject: @subject)
+    end
+  end
+end
+
+Decidim::Initiatives::InitiativesMailer.prepend(InitiativesMailerExtends)

--- a/spec/commands/decidim/blogs/admin/create_post_spec.rb
+++ b/spec/commands/decidim/blogs/admin/create_post_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Blogs
+    module Admin
+      describe CreatePost do
+        subject { described_class.new(form, current_user) }
+
+        let(:organization) { create :organization }
+        let(:participatory_process) { create :participatory_process, organization: organization }
+        let(:current_component) { create :component, participatory_space: participatory_process, manifest_name: "blogs" }
+        let(:current_user) { create :user, organization: organization }
+        let(:title) { "Post title" }
+        let(:body) { "Lorem Ipsum dolor sit amet" }
+
+        let(:invalid) { false }
+        let(:form) do
+          double(
+            invalid?: invalid,
+            title: { en: title },
+            body: { en: body },
+            current_component: current_component,
+            author: current_user
+          )
+        end
+
+        context "when the form is not valid" do
+          let(:invalid) { true }
+
+          it "is not valid" do
+            expect { subject.call }.to broadcast(:invalid)
+          end
+        end
+
+        context "when everything is ok" do
+          let(:post) { Post.last }
+
+          it "creates the post" do
+            expect { subject.call }.to change(Post, :count).by(1)
+          end
+
+          it "creates a searchable resource" do
+            expect { subject.call }.to change(Decidim::SearchableResource, :count).by_at_least(1)
+          end
+
+          it "sets the title" do
+            subject.call
+            expect(translated(post.title)).to eq title
+          end
+
+          it "sets the body" do
+            subject.call
+            expect(translated(post.body)).to eq body
+          end
+
+          it "sets the author" do
+            subject.call
+            expect(post.author).to eq current_user
+          end
+
+          it "sets the component" do
+            subject.call
+            expect(post.component).to eq current_component
+          end
+
+          it "broadcasts ok" do
+            expect { subject.call }.to broadcast(:ok)
+          end
+
+          it "sends a notification to the participatory space followers" do
+            follower = create(:user, organization: organization)
+            create(:follow, followable: participatory_process, user: follower)
+
+            expect(Decidim::EventsManager)
+              .to receive(:publish)
+              .with(
+                event: "decidim.events.blogs.post_created",
+                event_class: Decidim::Blogs::CreatePostEvent,
+                resource: kind_of(Post),
+                followers: [follower]
+              )
+
+            subject.call
+          end
+
+          it "sends an email to the followers" do
+            follower = create(:user, organization: organization)
+            create(:follow, followable: participatory_process, user: follower)
+
+            expect(Decidim::Blogs::BlogsMailer)
+              .to receive(:notify_post)
+              .with(kind_of(Post), follower, participatory_process)
+              .and_call_original
+
+            subject.call
+          end
+
+          it "traces the action", versioning: true do
+            expect(Decidim.traceability)
+              .to receive(:create!)
+              .with(Post, current_user, kind_of(Hash), visibility: "all")
+              .and_call_original
+
+            expect { subject.call }.to change(Decidim::ActionLog, :count)
+
+            action_log = Decidim::ActionLog.last
+            expect(action_log.version).to be_present
+            expect(action_log.version.event).to eq "create"
+          end
+
+          context "with a group author" do
+            let(:group) { create(:user_group, :verified, organization: organization) }
+            let(:form) do
+              double(
+                invalid?: invalid,
+                title: { en: title },
+                body: { en: body },
+                current_component: current_component,
+                author: group
+              )
+            end
+
+            it "sets the group as the author" do
+              subject.call
+              expect(post.author).to eq(group)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/commands/decidim/initiatives/admin/update_initiative_answer_spec.rb
+++ b/spec/commands/decidim/initiatives/admin/update_initiative_answer_spec.rb
@@ -38,6 +38,15 @@ module Decidim
                 command.call
               end
 
+              it "sends an email to the followers" do
+                expect(Decidim::Initiatives::InitiativesMailer)
+                  .to receive(:notify_answer)
+                  .with(initiative, follower)
+                  .and_call_original
+
+                command.call
+              end
+
               context "when the signature end time is not modified" do
                 let(:signature_end_date) { initiative.signature_end_date }
 


### PR DESCRIPTION
### Description

Additions of a new feature of emails when : 
- We receive an answer to an initiative.
- A new blog related to an initiative has been created.

### Additions :

- Initiative Answer
    I. Sending of an email, extending of the command
    II. Extend our mailer to add the new function "notify_answer"
    III. Creation of new views for our mail
    IV. Additions of test for this feature
- New Blog creation
    I. Sending of an email, extending of the command
    II. Creation of a mailer to send the email with the function "notify_blog"
    III. Creation of multiple views to create an email following the format of the other ones.
    IV. Additions of test for this feature
- Common changes
    I. Addition of few locales


### How to test (most efficient way to test)

- Boot your platform
- Log in as a user
- Follow one of the initiatives
- Log out and log in as an admin
- Go to the initiative
- With your admin, answer to the initiative in the BackOffice
- Check if you received the mail in letter_opener
- Go back to your initiative on "Blog"
- Create a Blog in the BackOffice with your admin
- Check if you received the mail in letter_opener

### NB : Those are temporary locales and email formats, if you need some changes, tell me and I'll do them.
