### PR TITLE
add module

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "decidim-initiatives", git: "https://github.com/decidim/decidim.git", branch
 
 ## Block gems /!\ Required comment for : $ rake app:upgrade
 gem "decidim-decidim_awesome", git: "https://github.com/decidim-ice/decidim-module-decidim_awesome.git", branch: "main"
+gem "decidim-blog_author_petition", git: "https://github.com/OpenSourcePolitics/decidim-module-blog_author_petition.git", branch: "main"
 # gem "acts_as_textcaptcha", "~> 4.5.1"
 # gem "decidim-homepage_interactive_map", git: "https://github.com/OpenSourcePolitics/decidim-module-homepage_interactive_map.git", branch: "bump/0.25-stable"
 # gem "decidim-phone_authorization_handler", git: "https://github.com/OpenSourcePolitics/decidim-module_phone_authorization_handler", branch: "bump/0.25-stable"
@@ -28,6 +29,7 @@ gem "activejob-uniqueness", require: "active_job/uniqueness/sidekiq_patch"
 gem "dotenv-rails"
 gem "fog-aws"
 gem "foundation_rails_helper", git: "https://github.com/sgruhier/foundation_rails_helper.git"
+gem "rack-attack"
 gem "sys-filesystem"
 
 gem "omniauth-rails_csrf_protection", "~> 1.0"

--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,8 @@ gem "decidim", git: "https://github.com/decidim/decidim.git", branch: DECIDIM_VE
 gem "decidim-initiatives", git: "https://github.com/decidim/decidim.git", branch: DECIDIM_VERSION
 
 ## Block gems /!\ Required comment for : $ rake app:upgrade
-gem "decidim-decidim_awesome", git: "https://github.com/decidim-ice/decidim-module-decidim_awesome.git", branch: "main"
 gem "decidim-blog_author_petition", git: "https://github.com/OpenSourcePolitics/decidim-module-blog_author_petition.git", branch: "main"
+gem "decidim-decidim_awesome", git: "https://github.com/decidim-ice/decidim-module-decidim_awesome.git", branch: "main"
 # gem "acts_as_textcaptcha", "~> 4.5.1"
 # gem "decidim-homepage_interactive_map", git: "https://github.com/OpenSourcePolitics/decidim-module-homepage_interactive_map.git", branch: "bump/0.25-stable"
 # gem "decidim-phone_authorization_handler", git: "https://github.com/OpenSourcePolitics/decidim-module_phone_authorization_handler", branch: "bump/0.25-stable"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-blog_author_petition.git
-  revision: 52540df6747342e135ff189bbfb51029af968f66
+  revision: 67bca52f4d362a57d2ffe3d31ca4295a4d82762e
   branch: main
   specs:
     decidim-blog_author_petition (0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,12 @@
 GIT
+  remote: https://github.com/OpenSourcePolitics/decidim-module-blog_author_petition.git
+  revision: 52540df6747342e135ff189bbfb51029af968f66
+  branch: main
+  specs:
+    decidim-blog_author_petition (0.1)
+      decidim-core (~> 0.27)
+
+GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-extended_socio_demographic_authorization_handler.git
   revision: 51be28cac256bc25c176e8a203aae7a00a9626bd
   branch: cese
@@ -975,6 +983,7 @@ DEPENDENCIES
   byebug (~> 11.0)
   dalli
   decidim!
+  decidim-blog_author_petition!
   decidim-decidim_awesome!
   decidim-dev!
   decidim-extended_socio_demographic_authorization_handler!
@@ -995,6 +1004,7 @@ DEPENDENCIES
   parallel_tests (~> 3.7)
   passenger
   puma (>= 5.6.2)
+  rack-attack
   rubocop-faker
   sendgrid-ruby
   sentry-rails


### PR DESCRIPTION
This PR adds the decidim blog author petition to the module.
It enables the author of a petition to manage its blog component.

- [x] Add module [decidim-module-blog_author_petition](https://github.com/OpenSourcePolitics/decidim-module-blog_author_petition)
- [x] Add missing `rack_attack` dependencie
