### PR TITLE
Fix and merge initiative show view

### DIFF
--- a/app/helpers/decidim/initiatives/initiative_print_helper.rb
+++ b/app/helpers/decidim/initiatives/initiative_print_helper.rb
@@ -6,7 +6,9 @@ module Decidim
       include Decidim::TranslatableAttributes
 
       def can_print?
-        current_initiative.published? && has_authorship_or_admin?(current_initiative, current_user)
+        return false if current_user.blank?
+
+        current_initiative.published? && current_initiative.has_authorship?(current_user)
       end
 
       def i18n_options
@@ -40,10 +42,6 @@ module Decidim
         return current_initiative.author.name unless authorization
 
         "#{authorization.metadata["first_name"]} #{authorization.metadata["last_name"]}"
-      end
-
-      def has_authorship_or_admin?(initiative, user)
-        initiative.has_authorship?(user) || current_user.admin?
       end
     end
   end

--- a/app/helpers/decidim/initiatives/initiative_print_helper.rb
+++ b/app/helpers/decidim/initiatives/initiative_print_helper.rb
@@ -4,6 +4,11 @@ module Decidim
   module Initiatives
     module InitiativePrintHelper
       include Decidim::TranslatableAttributes
+
+      def can_print?
+        current_initiative.published? && has_authorship_or_admin?(current_initiative, current_user)
+      end
+
       def i18n_options
         {
           name: author_name,
@@ -35,6 +40,10 @@ module Decidim
         return current_initiative.author.name unless authorization
 
         "#{authorization.metadata["first_name"]} #{authorization.metadata["last_name"]}"
+      end
+
+      def has_authorship_or_admin?(initiative, user)
+        initiative.has_authorship?(user) || current_user.admin?
       end
     end
   end

--- a/app/views/decidim/initiatives/initiatives/show.html.erb
+++ b/app/views/decidim/initiatives/initiatives/show.html.erb
@@ -1,22 +1,25 @@
+<% title = current_initiative.illegal? ? t(".illegal.title") : translated_attribute(current_initiative.title) %>
+<% description = current_initiative.illegal? ? t(".illegal.description") : translated_attribute(current_initiative.description) %>
+
 <% add_decidim_meta_tags({
-  image_url: current_initiative.type.attached_uploader(:banner_image).path,
-  description: translated_attribute(current_initiative.description),
-  title: translated_attribute(current_initiative.title),
-  url: initiative_url(current_initiative.id),
-  twitter_handler: current_organization.twitter_handler
-}) %>
+                           image_url: current_initiative.type.attached_uploader(:banner_image).path,
+                           description: description,
+                           title: title,
+                           url: initiative_url(current_initiative.id),
+                           twitter_handler: current_organization.twitter_handler
+                         }) %>
 
 <%
-edit_link(
-  resource_locator(current_participatory_space).edit,
-  :read,
-  :initiative
-)
+  edit_link(
+    resource_locator(current_participatory_space).edit,
+    :read,
+    :initiative
+  )
 %>
 
 <%= participatory_space_floating_help %>
 
-<% add_decidim_page_title(translated_attribute(current_initiative.title)) %>
+<% add_decidim_page_title(title) %>
 <% provide :meta_image_url, current_initiative.type.attached_uploader(:banner_image).path %>
 <div class="row">
   <% unless current_initiative.online_signature_type? %>
@@ -31,31 +34,36 @@ edit_link(
   <% end %>
 
   <div class="columns section view-side mediumlarge-4 mediumlarge-push-8 large-3 large-push-9">
-    <div class="card text-center">
-      <div class="card__content">
-        <% if current_initiative.published? || current_initiative.rejected? || current_initiative.accepted? %>
-          <%= render partial: "progress_bar" %>
-          <% if current_initiative.votes_enabled? %>
-            <div id="initiative-<%= current_initiative.id %>-vote-cabin">
-              <%= render partial: "vote_cabin", locals: { initiative: current_initiative } %>
-            </div>
+    <% if !current_initiative.invalidated? && !current_initiative.illegal? %>
+      <div class="card text-center">
+        <div class="card__content">
+          <% if current_initiative.published? || current_initiative.rejected? || current_initiative.accepted? %>
+            <%= render partial: "progress_bar" %>
+            <% if current_initiative.votes_enabled? %>
+              <div id="initiative-<%= current_initiative.id %>-vote-cabin">
+                <%= render partial: "vote_cabin", locals: { initiative: current_initiative } %>
+              </div>
+            <% end %>
+            <% if current_initiative.commentable? %>
+              <%= render partial: "interactions" %>
+            <% end %>
+          <% else %>
+            <%= link_to t(".edit"),
+                        edit_initiative_path(current_initiative),
+                        class: "button expanded" %>
+            <%= render partial: "send_to_technical_validation", locals: {
+              title: t(".send_to_technical_validation"),
+              confirm: t(".confirm")
+            } %>
           <% end %>
-          <%= render partial: "interactions" %>
-        <% else %>
-          <%= link_to t(".edit"),
-              edit_initiative_path(current_initiative),
-              class: "button expanded" %>
-          <%= render partial: "send_to_technical_validation", locals: {
-                                                                title: t(".send_to_technical_validation"),
-                                                                confirm: t(".confirm")
-                                                              } %>
-        <% end %>
-        <% if current_initiative.published? && current_user == current_initiative.author %>
-          <%= link_to t(".print"), print_initiative_path(current_initiative), class: "link action-print row" %>
-        <% end %>
+          <% if can_print? %>
+            <%= link_to t(".print"), print_initiative_path(current_initiative), class: "link action-print row" %>
+          <% end %>
+        </div>
       </div>
-    </div>
-    <% if current_user %>
+    <% end %>
+
+    <% if current_user && !current_initiative.illegal? %>
       <div class="card text-center">
         <div class="card__content">
           <%= cell "decidim/follow_button", current_participatory_space, inline: false, large: true %>
@@ -73,14 +81,15 @@ edit_link(
     <div class="section">
       <div class="row column">
         <h2 class="heading2">
-          <%= translated_attribute(current_initiative.title) %>
+          <%= title %>
         </h2>
         <%= render partial: "author", locals: { initiative: current_initiative } %>
       </div>
       <br>
       <div class="row column">
         <%= render partial: "initiative_badge", locals: { initiative: current_initiative } %>
-        <%= decidim_sanitize_editor translated_attribute(current_initiative.description) %>
+        <%= decidim_sanitize_editor description %>
+
         <%= render partial: "tags", locals: { resource: current_initiative } %>
       </div>
 
@@ -91,4 +100,4 @@ edit_link(
   </div>
 </div>
 
-<%= comments_for current_initiative if current_initiative.published? %>
+<%= comments_for current_initiative if current_initiative.commentable? && current_initiative.published? %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -98,7 +98,7 @@ ignore_missing:
  - decidim.initiatives.initiatives.show.{any_vote_method,offline_method,edit,send_to_technical_validation,confirm,follow_description}
  - decidim.proposals.omniauth.france_connect.external.{link,text}
  - decidim.proposals.omniauth.france_connect.forgot_password.ok_text
-
+ - decidim.initiatives.initiatives.show.illegal.{title,description}
 
 # Consider these keys used:
 ignore_unused:

--- a/spec/helpers/initiative_print_helper_spec.rb
+++ b/spec/helpers/initiative_print_helper_spec.rb
@@ -121,6 +121,12 @@ module Decidim
           end
         end
       end
+
+      describe "#can_print?" do
+        it "is true" do
+          expect(can_print?).to be_truthy
+        end
+      end
     end
   end
 end

--- a/spec/helpers/initiative_print_helper_spec.rb
+++ b/spec/helpers/initiative_print_helper_spec.rb
@@ -5,15 +5,16 @@ require "spec_helper"
 module Decidim
   module Initiatives
     describe InitiativePrintHelper do
+      let(:organization) { create(:organization) }
+      let(:user) { create(:user, :confirmed, organization: organization) }
+
       describe "#i18n_options" do
         before do
           allow(helper).to receive(:current_initiative).and_return(initiative)
         end
 
         context "when the author has completed the authorization" do
-          let(:user) { create(:user, :confirmed, organization: organization) }
           let(:initiative) { create(:initiative, :published, organization: organization, author: user) }
-          let(:organization) { create(:organization) }
 
           before do
             Decidim::Authorization.create!(
@@ -37,9 +38,7 @@ module Decidim
         end
 
         context "when the author has not completed the authorization" do
-          let(:user) { create(:user, :confirmed, organization: organization) }
           let(:initiative) { create(:initiative, :published, organization: organization, author: user) }
-          let(:organization) { create(:organization) }
 
           it "returns a hash" do
             expect(helper.i18n_options).to eq({
@@ -123,8 +122,51 @@ module Decidim
       end
 
       describe "#can_print?" do
-        it "is true" do
-          expect(can_print?).to be_truthy
+        before do
+          allow(helper).to receive(:current_initiative).and_return(initiative)
+          allow(helper).to receive(:current_user).and_return(user)
+        end
+
+        context "when user is author" do
+          let(:initiative) { create(:initiative, :published, organization: organization, author: user) }
+
+          it "returns true" do
+            expect(helper).to be_can_print
+          end
+
+          context "and initiative is not published" do
+            let(:initiative) { create(:initiative, :discarded, organization: organization, author: user) }
+
+            it "returns false" do
+              expect(helper).not_to be_can_print
+            end
+          end
+        end
+
+        context "and user is not author" do
+          let(:initiative) { create(:initiative, :published, organization: organization) }
+
+          it "returns false" do
+            expect(helper).not_to be_can_print
+          end
+        end
+
+        context "and user is admin" do
+          let(:user) { create(:user, :confirmed, :admin, organization: organization) }
+          let(:initiative) { create(:initiative, :published, organization: organization) }
+
+          it "returns false" do
+            expect(helper).not_to be_can_print
+          end
+        end
+
+        context "and user is not defined" do
+          let(:user) { nil }
+          let(:initiative) { create(:initiative, :published, organization: organization) }
+
+          it "returns false" do
+            expect(helper).not_to be_can_print
+          end
         end
       end
     end

--- a/spec/system/initiative_spec.rb
+++ b/spec/system/initiative_spec.rb
@@ -142,6 +142,31 @@ describe "Initiative", type: :system do
         expect(page).to have_css(".comments")
         expect(page).to have_content("0 Comments")
       end
+
+      context "when initiative state is illegal" do
+        let(:state) { :illegal }
+
+        before do
+          relogin_as initiative.author
+          visit decidim_initiatives.initiative_path(initiative)
+        end
+
+        it_behaves_like "initiative does not show signatures"
+
+        it "does not show content" do
+          within "main" do
+            expect(page).not_to have_content(translated(initiative.title, locale: :en))
+            expect(page).not_to have_content(ActionView::Base.full_sanitizer.sanitize(translated(initiative.description, locale: :en), tags: []))
+            expect(page).to have_content("Title content moderated")
+            expect(page).to have_content("Description content moderated")
+          end
+        end
+
+        it "displays initiative moderated title in title tab" do
+          expect(page).not_to have_title("#{translated(initiative.title)} - #{translated(initiative.title)} - #{organization.name}")
+          expect(page).to have_title("Title content moderated - Title content moderated - #{organization.name}")
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
#### Description

This PRs fixes multiples issues : 

- CTA "edit" / "send to technical validation" should be hidden for invalid and illegal petitions
- Print recepisse link should be only available for users (create helper method)
- Illegal initiative must have content hidden