### PR TITLE
[Feature] - Add Matomo's cookies config to CESE

### DIFF
--- a/app/views/layouts/decidim/_head_extra.html.erb
+++ b/app/views/layouts/decidim/_head_extra.html.erb
@@ -9,17 +9,20 @@
 
 <!-- Matomo -->
 <script>
-    var _paq = window._paq = window._paq || [];
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    _paq.push(["setDoNotTrack", true]);
-    _paq.push(['trackPageView']);
-    _paq.push(['enableLinkTracking']);
-    (function() {
-        var u="https://argus.osp.cat/";
-        _paq.push(['setTrackerUrl', u+'matomo.php']);
-        _paq.push(['setSiteId', '132']);
-        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-        g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-    })();
+    var consentCookie = JSON.parse(decodeURIComponent(document.cookie.replace(/(?:(?:^|.*;\s*)decidim-consent\s*=\s*([^;]*).*$)|^.*$/, "$1")));
+    if (consentCookie && consentCookie.analytics === true) {
+        var _paq = window._paq = window._paq || [];
+        /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+        _paq.push(["setDoNotTrack", true]);
+        _paq.push(['trackPageView']);
+        _paq.push(['enableLinkTracking']);
+        (function() {
+            var u="https://argus.osp.cat/";
+            _paq.push(['setTrackerUrl', u+'matomo.php']);
+            _paq.push(['setSiteId', '132']);
+            var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+            g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+        })();
+    }
 </script>
 <!-- End Matomo Code -->

--- a/app/views/layouts/decidim/_head_extra.html.erb
+++ b/app/views/layouts/decidim/_head_extra.html.erb
@@ -6,3 +6,20 @@
     });
   </script>
 <% end %>
+
+<!-- Matomo -->
+<script>
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(["setDoNotTrack", true]);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+        var u="https://argus.osp.cat/";
+        _paq.push(['setTrackerUrl', u+'matomo.php']);
+        _paq.push(['setSiteId', '132']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+</script>
+<!-- End Matomo Code -->

--- a/app/views/layouts/decidim/_head_extra.html.erb
+++ b/app/views/layouts/decidim/_head_extra.html.erb
@@ -23,6 +23,15 @@
             var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
             g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
         })();
+    } else if (consentCookie) {
+        // Clear Matomo cookies
+        var cookies = document.cookie.split("; ");
+        for (var i = 0; i < cookies.length; i++) {
+            if (cookies[i].indexOf("_pk_ses.") === 0 || cookies[i].indexOf("_pk_id.") === 0) {
+                var cookieName = cookies[i].split("=")[0];
+                document.cookie = cookieName + "=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
+            }
+        }
     }
 </script>
 <!-- End Matomo Code -->

--- a/app/views/layouts/decidim/_main_footer.html.erb
+++ b/app/views/layouts/decidim/_main_footer.html.erb
@@ -16,12 +16,12 @@
                 <li><%= link_to translated_attribute(page_topic.title), decidim.page_path(topic_pages.first) %></li>
               <% end %>
             <% end %>
-
             <% organization_pages.where(show_in_footer: true).each do |page| %>
               <li><%= link_to translated_attribute(page.title), decidim.page_path(page) %></li>
             <% end %>
           <% end %>
           <li><%= link_to t("layouts.decidim.footer.download_open_data"), decidim.open_data_download_path %></li>
+          <li><a href="#" data-open="dc-modal"><%= t("layouts.decidim.footer.data_consent_settings") %></a></li>
         </ul>
       </nav>
     </div>

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -24,6 +24,45 @@ Decidim.configure do |config|
     }
   }
 
+  config.consent_categories = [
+    {
+      slug: "essential",
+      mandatory: true,
+      items: [
+        {
+          type: "cookie",
+          name: "_session_id"
+        },
+        {
+          type: "cookie",
+          name: Decidim.consent_cookie_name
+        }
+      ]
+    },
+    {
+      slug: "preferences",
+      mandatory: false
+    },
+    {
+      slug: "analytics",
+      mandatory: false,
+      items: [
+        {
+          type: "cookie",
+          name: "_pk_id"
+        },
+        {
+          type: "cookie",
+          name: "_pk_ses"
+        }
+      ]
+    },
+    {
+      slug: "marketing",
+      mandatory: false
+    }
+  ]
+
   if defined?(Decidim::Initiatives) && defined?(Decidim::Initiatives.do_not_require_authorization)
     Decidim::Initiatives.minimum_committee_members = 1
     Decidim::Initiatives.do_not_require_authorization = true

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -223,6 +223,15 @@ en:
       - EN9
   layouts:
     decidim:
+      data_consent:
+        details:
+          items:
+            _pk_id:
+              description: This cookie is used by Matomo to recognize repeat visitors.
+              service: Matomo
+            _pk_ses:
+              description: This session cookie is used by Matomo to track the duration of a user's visit on the website.
+              service: Matomo
       footer:
         download_open_data: Open data
         made_with_open_source: Website made by <a target="_blank" href="https://opensourcepolitics.eu/en/">Open Source Politics</a> with the <a target="_blank" href="https://github.com/decidim/decidim">decidim free software</a>.

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -224,6 +224,15 @@ fr:
       - FR9
   layouts:
     decidim:
+      data_consent:
+        details:
+          items:
+            _pk_id:
+              description: Ce cookie est utilisé par Matomo pour reconnaître les visiteurs récurrents.
+              service: Matomo
+            _pk_ses:
+              description: Ce cookie de session est utilisé par Matomo pour suivre la durée de la visite d'un utilisateur sur le site.
+              service: Matomo
       footer:
         download_open_data: Données ouvertes
         made_with_open_source: Site réalisé par <a target="_blank" href="https://opensourcepolitics.eu">Open Source Politics</a> grâce au <a target="_blank" href="https://github.com/decidim/decidim">logiciel libre Decidim</a>.


### PR DESCRIPTION
## Description

This PR is made to add matomo's cookies management to the CESE according to the 0.27 version of Decidim

## Related Issues

This card [Notion](https://www.notion.so/opensourcepolitics/CESE-Cookies-f85befdaa5e641e593fcc395ea10f9db?pvs=4)