### PR TITLE
add translation for mobile phone confirmation

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -128,4 +128,5 @@ ignore_unused:
   - decidim.proposals.omniauth.france_connect.forgot_password.ok_text
   - layouts.decidim.data_consent.details.items.*
   - rack_attack.too_many_requests.*
-
+  - activemodel.attributes.confirmation.*
+  - activemodel.attributes.mobile_phone.*

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,6 +2,10 @@
 en:
   activemodel:
     attributes:
+      confirmation:
+        verification_code: Verification code
+      mobile_phone:
+        mobile_phone_number: Mobile phone number
       osp_authorization_handler:
         birthday: Birthday
         document_number: Unique number

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2,6 +2,10 @@
 fr:
   activemodel:
     attributes:
+      confirmation:
+        verification_code: Code de confirmation
+      mobile_phone:
+        mobile_phone_number: Numéro de téléphone
       osp_authorization_handler:
         birthday: Date de naissance
         document_number: Numéro unique


### PR DESCRIPTION
This PR adds the missing translations concerning the sms confirmation when signing a petition (missing in Decidim)
Related to [this notion card](https://www.notion.so/opensourcepolitics/bd4bf860eab94f9daca7da803f09e3b2?v=c96df65755dd403d95e86f82d7749709&p=fd77740742254fd1833d404139d8aeb4&pm=c)