### PR TITLE
Change session store to Active Record

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,8 @@ gem "sys-filesystem"
 
 gem "omniauth-rails_csrf_protection", "~> 1.0"
 
+gem "activerecord-session_store"
+
 gem "bootsnap", "~> 1.4"
 gem "puma", ">= 5.6.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,12 @@ GEM
     activerecord (6.1.7.3)
       activemodel (= 6.1.7.3)
       activesupport (= 6.1.7.3)
+    activerecord-session_store (2.0.0)
+      actionpack (>= 5.2.4.1)
+      activerecord (>= 5.2.4.1)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 2.0.8, < 3)
+      railties (>= 5.2.4.1)
     activestorage (6.1.7.3)
       actionpack (= 6.1.7.3)
       activejob (= 6.1.7.3)
@@ -991,6 +997,7 @@ PLATFORMS
 
 DEPENDENCIES
   activejob-uniqueness
+  activerecord-session_store
   bootsnap (~> 1.4)
   brakeman (~> 5.2)
   byebug (~> 11.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,5 +44,10 @@ module DevelopmentApp
       require "extends/controllers/decidim/devise/sessions_controller_extends"
       require "extends/forms/decidim/admin/organization_appearance_form_extends"
     end
+
+    initializer "session cookie domain", after: "Expire sessions" do
+      Rails.application.config.session_store :active_record_store, key: "_decidim_session", expire_after: Decidim.config.expire_session_after
+      ActiveRecord::SessionStore::Session.serializer = :hybrid
+    end
   end
 end

--- a/db/migrate/20230512092845_add_sessions_table.rb
+++ b/db/migrate/20230512092845_add_sessions_table.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddSessionsTable < ActiveRecord::Migration[6.1]
+  def change
+    create_table :sessions do |t|
+      t.string :session_id, null: false
+      t.text :data
+      t.timestamps
+    end
+
+    add_index :sessions, :session_id, unique: true
+    add_index :sessions, :updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_04_130043) do
+ActiveRecord::Schema.define(version: 2023_05_12_092845) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -1898,6 +1898,15 @@ ActiveRecord::Schema.define(version: 2023_04_04_130043) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["redirect_rule_id"], name: "index_request_environment_rules_on_redirect_rule_id"
+  end
+
+  create_table "sessions", force: :cascade do |t|
+    t.string "session_id", null: false
+    t.text "data"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["session_id"], name: "index_sessions_on_session_id", unique: true
+    t.index ["updated_at"], name: "index_sessions_on_updated_at"
   end
 
   create_table "versions", force: :cascade do |t|


### PR DESCRIPTION
We have some CookieOverflow when user submit long initiative texts. 
We rare switching to Active Record session store to fix this. 

⚠️ Dev Notes :  
Please see the special initializer used in `config/application.rb` to override Decidim code.