### PR TITLE
fix: User are verifiable if unconfirmed access is enable

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -48,6 +48,7 @@ module DevelopmentApp
       require "extends/forms/decidim/initiatives/initiative_form_extends"
       require "extends/controllers/decidim/devise/sessions_controller_extends"
       require "extends/forms/decidim/admin/organization_appearance_form_extends"
+      require "extends/models/decidim/user_extends"
     end
 
     initializer "session cookie domain", after: "Expire sessions" do

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -19,6 +19,8 @@ Decidim.configure do |config|
   # Timeout session
   config.expire_session_after = ENV.fetch("DECIDIM_SESSION_TIMEOUT", 180).to_i.minutes
 
+  config.unconfirmed_access_for = ENV.fetch("DECIDIM_UNCONFIRMED_ACCESS", 0).to_i.days
+
   config.maximum_attachment_height_or_width = 6000
 
   # Whether SSL should be forced or not (only in production).

--- a/lib/extends/models/decidim/user_extends.rb
+++ b/lib/extends/models/decidim/user_extends.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module UserExtends
+  extend ActiveSupport::Concern
+
+  included do
+    # Whether this user can be verified against some authorization or not.
+    def verifiable?
+      Decidim.config.unconfirmed_access_for.positive? || confirmed? || managed? || being_impersonated?
+    end
+  end
+end
+
+Decidim::User.class_eval do
+  include(UserExtends)
+end


### PR DESCRIPTION
- Fix Decidim configuration for `DECIDIM_UNCONFIRMED_ACCESS` env variable
- User are verifiable if unconfirmed access is enable