### PR TITLE
Fix unconfirmed access configuration loading

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -19,6 +19,10 @@ Decidim.configure do |config|
   # Timeout session
   config.expire_session_after = ENV.fetch("DECIDIM_SESSION_TIMEOUT", 180).to_i.minutes
 
+  # Devise unconfirmed access
+  # see also config/initializers/devise.rb line 27
+  config.unconfirmed_access_for = ENV.fetch("DECIDIM_UNCONFIRMED_ACCESS", 0).to_i.days
+
   config.maximum_attachment_height_or_width = 6000
 
   # Whether SSL should be forced or not (only in production).


### PR DESCRIPTION
Devise unconfirmed access need also to be loaded into the Decidim configuration scope