### PR TITLE
feat: Remove decidim-extended_socio_demographic_authorization_handler gem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,5 @@ yarn-debug.log*
 .yarn-integrity
 *.rubocop-https*
 certificate-https-local/
+
+.DS_Store

--- a/Gemfile
+++ b/Gemfile
@@ -17,8 +17,6 @@ gem "decidim-initiatives", "~> #{DECIDIM_VERSION}.0"
 # External Decidim gems
 gem "decidim-blog_author_petition", git: "https://github.com/OpenSourcePolitics/decidim-module-blog_author_petition.git", branch: "main"
 gem "decidim-decidim_awesome", git: "https://github.com/decidim-ice/decidim-module-decidim_awesome.git", branch: "main"
-gem "decidim-extended_socio_demographic_authorization_handler", git: "https://github.com/OpenSourcePolitics/decidim-module-extended_socio_demographic_authorization_handler.git",
-                                                                branch: "cese"
 gem "decidim-initiative_status", git: "https://github.com/OpenSourcePolitics/decidim-module-initiative_status.git", branch: "main"
 gem "decidim-spam_detection"
 gem "decidim-term_customizer", git: "https://github.com/armandfardeau/decidim-module-term_customizer.git", branch: "fix/precompile-on-docker-0.27"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,14 +7,6 @@ GIT
       decidim-core (~> 0.27)
 
 GIT
-  remote: https://github.com/OpenSourcePolitics/decidim-module-extended_socio_demographic_authorization_handler.git
-  revision: f51e6314e014fe89156b1115dbd7fe14ecaa5565
-  branch: cese
-  specs:
-    decidim-extended_socio_demographic_authorization_handler (0.26.1)
-      decidim-core (~> 0.27)
-
-GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module-initiative_status.git
   revision: eae4e5440fc84adac72097afb6e06ec172795dd4
   branch: main
@@ -1032,7 +1024,6 @@ DEPENDENCIES
   decidim-blog_author_petition!
   decidim-decidim_awesome!
   decidim-dev (~> 0.27.0)
-  decidim-extended_socio_demographic_authorization_handler!
   decidim-initiative_status!
   decidim-initiatives (~> 0.27.0)
   decidim-spam_detection

--- a/db/migrate/20231206212031_delete_extended_socio_demographic_authorization_handler_settings_on_initiatives.rb
+++ b/db/migrate/20231206212031_delete_extended_socio_demographic_authorization_handler_settings_on_initiatives.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class DeleteExtendedSocioDemographicAuthorizationHandlerSettingsOnInitiatives < ActiveRecord::Migration[6.1]
+  def change
+    Decidim::InitiativesType.where(document_number_authorization_handler: "extended_socio_demographic_authorization_handler").each do |initiatives_type|
+      initiatives_type.update!(document_number_authorization_handler: nil)
+    end
+
+    Decidim::ResourcePermission.all.each do |resource_permission|
+      next if resource_permission.permissions.blank?
+
+      resource_permission.permissions.each do |action, authorization|
+        if authorization.has_key?("authorization_handlers") && authorization["authorization_handlers"].has_key?("extended_socio_demographic_authorization_handler")
+          resource_permission.permissions.delete(action)
+        end
+      end
+
+      resource_permission.save! if resource_permission.changed?
+    end
+  end
+end

--- a/db/migrate/20231206230804_migrate_extended_socio_demographic_authorization_handler_data.rb
+++ b/db/migrate/20231206230804_migrate_extended_socio_demographic_authorization_handler_data.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class MigrateExtendedSocioDemographicAuthorizationHandlerData < ActiveRecord::Migration[6.1]
+  def change
+    Decidim::Authorization.where(name: "extended_socio_demographic_authorization_handler").each do |authorization|
+      next if authorization.user.deleted?
+
+      # We don't migrate the email because we don't want to confirm it if needed
+      authorization.user.name = "#{authorization.metadata["first_mane"]} #{authorization.metadata["first_mane"]}"
+      authorization.user.extended_data = {
+        city: authorization.metadata["city"],
+        address: authorization.metadata["address"],
+        birth_date: authorization.metadata["birth_date"],
+        postal_code: authorization.metadata["postal_code"],
+        certification: authorization.metadata["certification"]
+      }
+      authorization.user.save
+      authorization.delete
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_12_092845) do
+ActiveRecord::Schema.define(version: 2023_12_06_230804) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -577,6 +577,56 @@ ActiveRecord::Schema.define(version: 2023_05_12_092845) do
     t.index ["follows_count"], name: "index_decidim_debates_debates_on_follows_count"
   end
 
+  create_table "decidim_dummy_resources_coauthorable_dummy_resources", force: :cascade do |t|
+    t.jsonb "translatable_text"
+    t.string "title"
+    t.string "body"
+    t.text "address"
+    t.float "latitude"
+    t.float "longitude"
+    t.datetime "published_at"
+    t.integer "coauthorships_count", default: 0, null: false
+    t.integer "endorsements_count", default: 0, null: false
+    t.integer "comments_count", default: 0, null: false
+    t.bigint "decidim_component_id"
+    t.bigint "decidim_category_id"
+    t.bigint "decidim_scope_id"
+    t.string "reference"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "decidim_dummy_resources_dummy_resources", force: :cascade do |t|
+    t.jsonb "translatable_text"
+    t.jsonb "title"
+    t.string "body"
+    t.text "address"
+    t.float "latitude"
+    t.float "longitude"
+    t.datetime "published_at"
+    t.integer "coauthorships_count", default: 0, null: false
+    t.integer "endorsements_count", default: 0, null: false
+    t.integer "comments_count", default: 0, null: false
+    t.integer "follows_count", default: 0, null: false
+    t.bigint "decidim_component_id"
+    t.integer "decidim_author_id"
+    t.string "decidim_author_type"
+    t.integer "decidim_user_group_id"
+    t.bigint "decidim_category_id"
+    t.bigint "decidim_scope_id"
+    t.string "reference"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "decidim_dummy_resources_nested_dummy_resources", force: :cascade do |t|
+    t.jsonb "translatable_text"
+    t.string "title"
+    t.bigint "dummy_resource_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "decidim_editor_images", force: :cascade do |t|
     t.bigint "decidim_author_id", null: false
     t.bigint "decidim_organization_id", null: false
@@ -591,7 +641,7 @@ ActiveRecord::Schema.define(version: 2023_05_12_092845) do
     t.bigint "resource_id"
     t.string "decidim_author_type"
     t.bigint "decidim_author_id"
-    t.integer "decidim_user_group_id"
+    t.integer "decidim_user_group_id", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["decidim_author_type", "decidim_author_id"], name: "idx_endorsements_authors"
@@ -1679,6 +1729,18 @@ ActiveRecord::Schema.define(version: 2023_05_12_092845) do
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_decidim_system_admins_on_email", unique: true
     t.index ["reset_password_token"], name: "index_decidim_system_admins_on_reset_password_token", unique: true
+  end
+
+  create_table "decidim_templates_templates", force: :cascade do |t|
+    t.integer "decidim_organization_id", null: false
+    t.string "templatable_type"
+    t.bigint "templatable_id"
+    t.jsonb "name", null: false
+    t.jsonb "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["decidim_organization_id"], name: "index_decidim_templates_organization"
+    t.index ["templatable_type", "templatable_id"], name: "index_decidim_templates_templatable"
   end
 
   create_table "decidim_term_customizer_constraints", force: :cascade do |t|


### PR DESCRIPTION
- remove the decidim-extended_socio_demographic_authorization_handler gem dependency
- delete all initiative configuration related to this handler (vote ? create / comment permissions)
- move authorization metadata from this handler to the user extended data. (email is not considered because of confirmation)
- delete all authorization related to this handler