### PR TITLE
feat: Add TOS to Omniauth Registration Form

### DIFF
--- a/app/commands/decidim/create_omniauth_registration.rb
+++ b/app/commands/decidim/create_omniauth_registration.rb
@@ -62,6 +62,8 @@ module Decidim
         @user.email = (verified_email || form.email)
         @user.name = form.name
         @user.nickname = form.normalized_nickname
+        @user.tos_agreement = form.tos_agreement
+        @user.accepted_tos_version = form.current_organization.tos_version
         @user.newsletter_notifications_at = nil
         @user.password = generated_password
         @user.password_confirmation = generated_password
@@ -75,7 +77,6 @@ module Decidim
         @user.skip_confirmation! if verified_email
       end
 
-      @user.tos_agreement = "1"
       @user.save!
     end
 

--- a/app/packs/src/confirmation_registration.js
+++ b/app/packs/src/confirmation_registration.js
@@ -8,6 +8,17 @@ $(document).ready(() => {
         }
     });
 
+    $("#user_tos_agreement").on("change", function(e) {
+        const tosField = event.target.parentNode.parentNode;
+        const tosError = tosField.querySelectorAll('.form-error');
+
+        if (tosError) {
+            tosError.forEach(error => {
+                error.remove();
+            });
+        }
+    });
+
     $(".select-date-container").on("change", function(e) {
         const dateField = event.target.parentNode.parentNode;
         const dateError = dateField.querySelectorAll('.form-error');

--- a/app/views/decidim/devise/omniauth_registrations/new.html.erb
+++ b/app/views/decidim/devise/omniauth_registrations/new.html.erb
@@ -69,6 +69,20 @@
                   </div>
                 </div>
 
+                <div class="card" id="card__tos">
+                  <div class="card__content">
+                    <h3><%= t(".tos_title") %></h3>
+
+                    <p class="tos-text">
+                      <%= strip_tags(translated_attribute(Decidim::StaticPage.find_by(slug: "terms-and-conditions", organization: current_organization).content)) %>
+                    </p>
+
+                    <div class="field">
+                      <%= f.check_box :tos_agreement, label: t(".tos_agreement", link: link_to(t(".terms"), page_path("terms-and-conditions"))) %>
+                    </div>
+                  </div>
+                </div>
+
                 <%= f.hidden_field :email %>
                 <%= f.hidden_field :uid %>
                 <%= f.hidden_field :name %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,6 +72,9 @@ en:
           registration_info: Please complete your profile
           sign_up: Sign up
           subtitle: Create your account
+          terms: the terms and conditions of use
+          tos_agreement: By signing up you agree to %{link}.
+          tos_title: Terms of Service
       registrations:
         form:
           errors:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -72,6 +72,9 @@ fr:
           registration_info: Renseignez vos informations personnelles
           sign_up: Renseignez vos informations personnelles
           subtitle: Vous êtes sur le point de créer un compte sur la plateforme de pétitions du CESE.
+          terms: les termes et conditions d'utilisation
+          tos_agreement: En vous créant un compte, vous acceptez %{link}.
+          tos_title: Conditions d'utilisation
       registrations:
         form:
           errors:

--- a/lib/extends/forms/decidim/omniauth_registration_form_extend.rb
+++ b/lib/extends/forms/decidim/omniauth_registration_form_extend.rb
@@ -11,6 +11,7 @@ module OmniauthRegistrationFormExtend
     attribute :address, String
     attribute :postal_code, String
     attribute :city, String
+    attribute :tos_agreement, ::ActiveModel::Type::Boolean
 
     validates :email, "valid_email_2/email": { mx: true }
     validates :postal_code,
@@ -18,10 +19,12 @@ module OmniauthRegistrationFormExtend
               :city,
               :address,
               :certification,
-              presence: true, unless: ->(form) { form.certification.blank? }
+              :tos_agreement,
+              presence: true, unless: ->(form) { form.tos_agreement.blank? }
 
-    validates :postal_code, numericality: { only_integer: true }, length: { is: 5 }, unless: ->(form) { form.certification.blank? }
-    validates :certification, acceptance: true, presence: true
+    validates :postal_code, numericality: { only_integer: true }, length: { is: 5 }, unless: ->(form) { form.tos_agreement.blank? }
+    validates :certification, acceptance: true, presence: true, unless: ->(form) { form.tos_agreement.blank? }
+    validates :tos_agreement, acceptance: true, presence: true
     validate :over_16?
 
     private


### PR DESCRIPTION
#### :tophat: Description
This PR has been made to move TOS confirmation to the omniauth registration form to delete a step for our registration.

#### :pushpin: Related Issues
*Link your PR to an issue*
- [Notion card](https://www.notion.so/opensourcepolitics/CESE-Recette-0de16ee67bd64bf484c73453b73efcc9?pvs=4)

#### Testing
*Describe the best way to test or validate your PR.*

Example:
* Log in using FC
* Complete the form
* Confirm your account
* Reconnect
* Check that you don't have to check the TOS

#### Tasks
- [x] Add the TOS checkbox
- [x] Add the TOS acceptation in the omniauth registration
- [x] Modify JS to adapt the form to the new changes

### :camera: Screenshots
*Please add screenshots of the changes you're proposing if related to the UI*
