### PR TITLE
fix: omniauth users are confirmed directly at sign up

### DIFF
--- a/app/controllers/decidim/omniauth_registrations_controller_override.rb
+++ b/app/controllers/decidim/omniauth_registrations_controller_override.rb
@@ -21,6 +21,22 @@ module Decidim
           super
         end
       end
+
+      private
+
+      def verified_email
+        @verified_email ||= find_verified_email
+      end
+
+      def find_verified_email
+        if oauth_data.present?
+          session["oauth_data.verified_email"] = oauth_data.dig(:info, :email)
+        else
+          email_from_session = session["oauth_data.verified_email"]
+          session.delete("oauth_data.verified_email")
+          email_from_session
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
When a user sign up with an omniauth account and they need to complete its profile, we need to store the verified from the omniauth hash to use it in the creation command.  
We use a session variable because we can't trust the email coming from the omniauth registration form (it can be changed in the HTML before submit).