### PR TITLE
backport: Add missing jobs for initiatives rake tasks

### DIFF
--- a/app/jobs/check_published_initiatives.rb
+++ b/app/jobs/check_published_initiatives.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CheckPublishedInitiatives < ApplicationJob
+  def perform
+    system "rake decidim_initiatives:check_published"
+  end
+end

--- a/app/jobs/check_validating_initiatives.rb
+++ b/app/jobs/check_validating_initiatives.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CheckValidatingInitiatives < ApplicationJob
+  def perform
+    system "rake decidim_initiatives:check_validating"
+  end
+end

--- a/app/jobs/notify_progress_initiatives.rb
+++ b/app/jobs/notify_progress_initiatives.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class NotifyProgressInitiatives < ApplicationJob
+  def perform
+    system "rake decidim_initiatives:notify_progress"
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -13,6 +13,7 @@
   - metrics
   - vote_reminder
   - reminders
+  - initiatives
 
 :scheduler:
   :schedule:
@@ -48,3 +49,15 @@
       cron: '0 5 0 * * 6' # Run at 00:05 on Saturday
       class: SendNotificationMailWeeklyJob
       queue: mailers
+    CheckPublishedInitiatives:
+      cron: '0 1 * * *'
+      class: CheckPublishedInitiatives
+      queue: initiatives
+    CheckValidatingInitiatives:
+      cron: '0 1 * * *'
+      class: CheckValidatingInitiatives
+      queue: initiatives
+    NotifyProgressInitiatives:
+      cron: '0 1 * * *'
+      class: NotifyProgressInitiatives
+      queue: initiatives


### PR DESCRIPTION
#### :tophat: Description

This will scheduled on daily moe these 3 rake tasks : 

- `decidim_initiatives:check_validating`
- `decidim_initiatives:check_published`
- `decidim_initiatives:notify_progress`

#### :pushpin: Related Issues
- [CESE - Add initiative rake tasks](https://opensourcepolitics.odoo.com/web?db=opensourcepolitics&signup_email=guillaume%40opensourcepolitics.eu&token=ixqNZ9S5lGRCj9ADpsQq#id=3669&cids=1&menu_id=325&action=471&model=project.task&view_type=form)
