### PR TITLE
Release master > develop

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -40,3 +40,7 @@ DECIDIM_ADMIN_PASSWORD_STRONG="false"
 
 # Override after confirmation path with custom route
 # AH_REDIRECT_AFTER_CONFIRMATION="/initiatives"
+
+# Automatically save AH metadata to user extended data
+# Format : comma separated list of auhtorization handler names
+# AUTO_EXPORT_AUTHORIZATIONS_DATA_TO_USER_DATA_ENABLED_FOR="authorization1,authorization2"

--- a/app/jobs/authorization_data_to_user_data_job.rb
+++ b/app/jobs/authorization_data_to_user_data_job.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AuthorizationDataToUserDataJob < ApplicationJob
+  queue_as :exports
+
+  def perform(*args)
+    Decidim::AuthorizationDataToUserDataService.run(*args)
+  end
+end

--- a/app/jobs/check_published_initiatives.rb
+++ b/app/jobs/check_published_initiatives.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CheckPublishedInitiatives < ApplicationJob
+  def perform
+    system "rake decidim_initiatives:check_published"
+  end
+end

--- a/app/jobs/check_validating_initiatives.rb
+++ b/app/jobs/check_validating_initiatives.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CheckValidatingInitiatives < ApplicationJob
+  def perform
+    system "rake decidim_initiatives:check_validating"
+  end
+end

--- a/app/jobs/notify_progress_initiatives.rb
+++ b/app/jobs/notify_progress_initiatives.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class NotifyProgressInitiatives < ApplicationJob
+  def perform
+    system "rake decidim_initiatives:notify_progress"
+  end
+end

--- a/app/services/decidim/authorization_data_to_user_data_service.rb
+++ b/app/services/decidim/authorization_data_to_user_data_service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Decidim
+  class AuthorizationDataToUserDataService
+    def self.run(**args)
+      new(**args).execute
+    end
+
+    def initialize(**args)
+      @name = args[:name]
+      @user = args[:user]
+    end
+
+    def execute
+      Decidim::Authorization.find_each(filter) do |authorization|
+        authorization.user.update(extended_data: authorization.user.extended_data.merge({ @name.to_s => authorization.metadata }))
+      end
+    end
+
+    def filter
+      @filter ||= {
+        name: @name,
+        user: @user
+      }.compact
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,6 +51,7 @@ module DevelopmentApp
       require "extends/forms/decidim/admin/organization_appearance_form_extends"
       require "extends/omniauth/strategies/france_connect_extends"
       require "extends/forms/decidim/omniauth_registration_form_extend"
+      require "extends/models/decidim/authorization_extends"
     end
 
     initializer "session cookie domain", after: "Expire sessions" do

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -231,7 +231,7 @@ fr:
       send_resume:
         body:
           confirm: Vous pouvez toujours confirmer votre compte et signer à nouveau les pétitions de votre choix. Pour cela, cliquez sur le bouton de renvoi des instructions de confirmation sur la page de connexion de la plateforme.
-          title: Vous n’avez pas confirmé votre compte sur la plateforme de pétitions du CESE , les signatures suivantes ont donc été annulées :
+          title: Vous n’avez pas confirmé votre compte sur la plateforme de pétitions du CESE , les signatures suivantes ont donc été annulées
           vote: Votre signature de la pétition '%{initiative_title}' a été annulée.
         subject: Vous n'avez pas confirmé votre compte, vos signatures ont donc été annulées
     verifications:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -56,7 +56,7 @@ fr:
           body: Veuillez confirmer votre compte en cliquant sur le lien ci-dessous.
           confirmation_link: Lien de confirmation
           title: Vous avez créé un compte il y a 2 jours mais vous ne l'avez pas encore confirmé.
-          warning: L'ensemble de vos votes seront supprimés dans 6 jours si votre compte n'est pas confirmé dans ce délai.
+          warning: L'ensemble de vos signatures seront annulées dans 6 jours si vous ne confirmez pas votre compte.
         subject: Veuillez confirmer votre compte
     devise:
       omniauth_registrations:
@@ -230,10 +230,10 @@ fr:
     unconfirmed_votes_clear_mailer:
       send_resume:
         body:
-          confirm: Vous pouvez toujours confirmer votre compte et voter à nouveau sur les pétitions.
-          title: Vous n'avez pas confirmé votre compte, les votes que vous avez fait ont été supprimés
-          vote: Votre vote sur la pétition '%{initiative_title}' a été supprimé.
-        subject: Vous n'avez pas confirmé votre compte, vos votes ont été supprimés
+          confirm: Vous pouvez toujours confirmer votre compte et signer à nouveau les pétitions de votre choix. Pour cela, cliquez sur le bouton de renvoi des instructions de confirmation sur la page de connexion de la plateforme.
+          title: Vous n’avez pas confirmé votre compte sur la plateforme de pétitions du CESE , les signatures suivantes ont donc été annulées :
+          vote: Votre signature de la pétition '%{initiative_title}' a été annulée.
+        subject: Vous n'avez pas confirmé votre compte, vos signatures ont donc été annulées
     verifications:
       authorizations:
         create:

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -13,6 +13,8 @@
 default: &default
   asset_host: <%= ENV["ASSET_HOST"] %>
   decidim:
+    authorizations:
+      export_data_to_userdata_enabled_for: <%= ENV.fetch("AUTO_EXPORT_AUTHORIZATIONS_DATA_TO_USER_DATA_ENABLED_FOR", "") %>
     reminder:
       unconfirmed_email:
         days: <%= ENV["DECIDIM_REMINDER_UNCONFIRMED_EMAIL_DAYS"]&.to_i || 2 %>

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -13,6 +13,7 @@
   - metrics
   - vote_reminder
   - reminders
+  - initiatives
 
 :scheduler:
   :schedule:
@@ -48,3 +49,15 @@
       cron: '0 5 0 * * 6' # Run at 00:05 on Saturday
       class: SendNotificationMailWeeklyJob
       queue: mailers
+    CheckPublishedInitiatives:
+      cron: '0 1 * * *'
+      class: CheckPublishedInitiatives
+      queue: initiatives
+    CheckValidatingInitiatives:
+      cron: '0 1 * * *'
+      class: CheckValidatingInitiatives
+      queue: initiatives
+    NotifyProgressInitiatives:
+      cron: '0 1 * * *'
+      class: NotifyProgressInitiatives
+      queue: initiatives

--- a/lib/extends/models/decidim/authorization_extends.rb
+++ b/lib/extends/models/decidim/authorization_extends.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+module AuthorizationExtends
+  extend ActiveSupport::Concern
+
+  included do
+    after_commit :export_to_user_extended_data, if: proc { |authorization|
+      Rails.application.secrets.dig(:decidim, :export_data_to_userdata_enabled_for)&.split(",")&.include?(authorization.name)
+    }
+
+    def export_to_user_extended_data
+      Decidim::AuthorizationDataToUserDataService.run(name: name, user: user)
+    end
+  end
+end
+
+Decidim::Authorization.include(AuthorizationExtends)

--- a/lib/tasks/authorizations.rake
+++ b/lib/tasks/authorizations.rake
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+namespace :authorizations do
+  task export_to_user_extended_data: :environment do
+    name = ENV["AUTHORIZATION_HANDLE_NAME"].presence
+    raise "AUTHORIZATION_HANDLE_NAME is blank." if name.blank?
+
+    raise "No data found for authorization handler name '#{name}'" unless Decidim::Authorization.exists?(name: name)
+
+    AuthorizationDataToUserDataJob.perform_later(name: name)
+  end
+end

--- a/spec/mailers/confirmation_reminder_mailer_spec.rb
+++ b/spec/mailers/confirmation_reminder_mailer_spec.rb
@@ -33,7 +33,7 @@ module Decidim
         it "parses the body in the user's locale" do
           expect(email_body(mail)).to include("Vous avez créé un compte il y a 2 jours mais vous ne l'avez pas encore confirmé.")
           expect(email_body(mail)).to include("Veuillez confirmer votre compte en cliquant sur le lien ci-dessous.")
-          expect(email_body(mail)).to include("L'ensemble de vos votes seront supprimés dans 6 jours si votre compte n'est pas confirmé dans ce délai.")
+          expect(email_body(mail)).to include("L'ensemble de vos signatures seront annulées dans 6 jours si vous ne confirmez pas votre compte.")
         end
       end
     end

--- a/spec/mailers/unconfirmed_votes_clear_mailer_spec.rb
+++ b/spec/mailers/unconfirmed_votes_clear_mailer_spec.rb
@@ -34,14 +34,14 @@ module Decidim
         end
 
         it "parses the subject in the user's locale" do
-          expect(mail.subject).to eq("Vous n'avez pas confirmé votre compte, vos votes ont été supprimés")
+          expect(mail.subject).to eq("Vous n'avez pas confirmé votre compte, vos signatures ont donc été annulées")
         end
 
         it "parses the body in the user's locale" do
-          expect(email_body(mail)).to include("Vous n'avez pas confirmé votre compte, les votes que vous avez fait ont été supprimés")
-          expect(email_body(mail)).to include("Vous pouvez toujours confirmer votre compte et voter à nouveau sur les pétitions.")
+          expect(email_body(mail)).to include("Vous n’avez pas confirmé votre compte sur la plateforme de pétitions du CESE , les signatures suivantes ont donc été annulées")
+          expect(email_body(mail)).to include("Vous pouvez toujours confirmer votre compte et signer à nouveau les pétitions de votre choix.")
           initiatives.each do |initiative|
-            expect(email_body(mail)).to include("Votre vote sur la pétition '#{translated(initiative.title)}' a été supprimé.")
+            expect(email_body(mail)).to include("Votre signature de la pétition '#{translated(initiative.title)}' a été annulée.")
           end
         end
       end


### PR DESCRIPTION
#### :tophat: Description
Backport of 2 features: 
- #97 
- #96 

This one schedule 3 rake tasks : 
`decidim_initiatives:check_validating`
`decidim_initiatives:check_published`
`decidim_initiatives:notify_progress`

#### Environment variables
- `AUTO_EXPORT_AUTHORIZATIONS_DATA_TO_USER_DATA_ENABLED_FOR` (default: `""`). Define if AH data are duplicated in the user's metatada
- `AUTHORIZATION_HANDLE_NAME`. Used in `be rake authorizations:export_to_user_extended_data`
#### :pushpin: Related Issues
- Related to https://opensourcepolitics.odoo.com/odoo/all-tasks/2449 & https://opensourcepolitics.odoo.com/odoo/all-tasks/3669
